### PR TITLE
Fix native macOS run destination

### DIFF
--- a/Sources/Showcase/LabelPlayground.swift
+++ b/Sources/Showcase/LabelPlayground.swift
@@ -6,6 +6,11 @@
 import SwiftUI
 
 struct LabelPlayground: View {
+    #if os(macOS)
+    let placement: ToolbarItemPlacement = .automatic
+    #else
+    let placement: ToolbarItemPlacement = .topBarLeading
+    #endif
     var body: some View {
         ScrollView {
             VStack(spacing: 16) {
@@ -42,7 +47,8 @@ struct LabelPlayground: View {
             }
             .padding()
             .toolbar {
-                ToolbarItemGroup(placement: .topBarLeading) {
+                ToolbarItemGroup(placement: placement
+                ) {
                     Label("Icon Only", systemImage: "heart.fill")
                     Label("+ Title", systemImage: "star.fill")
                         .labelStyle(.titleAndIcon)

--- a/Sources/Showcase/TabViewPlayground.swift
+++ b/Sources/Showcase/TabViewPlayground.swift
@@ -22,12 +22,16 @@ struct TabViewPlayground: View {
                     }
                 Text("More (page 2)")
             }
+            #if !os(macOS) || os(Android)
             .tabViewStyle(.page)
+            #endif
             .tabItem { Label("Favorites", systemImage: "heart.fill") }
             .tag("Favorites")
+            #if !os(macOS) || os(Android)
             TabPageViewContentView()
                 .tabItem { Label("Paging", systemImage: "arrow.forward.square") }
                 .tag("Paging")
+            #endif
         }
         .tint(.red)
         .toolbar {
@@ -53,11 +57,13 @@ struct TabPlaygroundContentView: View {
                     selectedTab = "Favorites"
                 }
             }
+            #if !os(macOS) || os(Android)
             if label != "Paging" {
                 Button("Switch to Paging") {
                     selectedTab = "Paging"
                 }
             }
+            #endif
         }
     }
 }

--- a/Sources/Showcase/TextFieldPlayground.swift
+++ b/Sources/Showcase/TextFieldPlayground.swift
@@ -54,7 +54,9 @@ struct TextFieldPlayground: View {
                     }
                 TextField("(###) ###-####", text: $phone)
                     .textFieldStyle(.plain)
+                    #if !os(macOS) || os(Android)
                     .keyboardType(UIKeyboardType.phonePad)
+                    #endif
                     .onChange(of: phone) { newValue in
                         phone = formatPhone(newValue)
                     }


### PR DESCRIPTION
The showcase app was refusing to run with "My Mac" as the Run Destination. When I apply these changes, it builds.

<s>However! When I apply these changes, it causes the `#if !os(macOS)` modifiers to disappear on Android as well. It works as expected in the LabelPlayground, but in the TextFieldPlayground, the phone field stops using the phone keyboard, and the Paging tab of the TabViewPlayground goes away. I'll file a separate bug on this.</s>

EDIT: I worked around https://github.com/skiptools/skip/issues/342 and now this PR should be ready to merge.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test` (but the showcase has no tests!)
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

