### PR TITLE
Make Showcase tab searchable on macOS

### DIFF
--- a/Sources/Showcase/PlaygroundListView.swift
+++ b/Sources/Showcase/PlaygroundListView.swift
@@ -379,8 +379,8 @@ public struct PlaygroundNavigationView: View {
             .navigationDestination(for: PlaygroundType.self) {
                 $0.navigationTitle(Text($0.title))
             }
+            .searchable(text: $searchText)
         }
-        .searchable(text: $searchText)
     }
 
     private func matchingPlaygroundTypes() -> [PlaygroundType] {


### PR DESCRIPTION
This change has no effect on iOS or Android.

# Before

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/244d1119-8d0c-4d19-9cca-7969c54dd12a" />


# After

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/de003a16-522f-4538-94fa-6484e4fba529" />


- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

