### PR TITLE
Add focus state binding example for child view

### DIFF
--- a/Sources/Showcase/FocusStatePlayground.swift
+++ b/Sources/Showcase/FocusStatePlayground.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct FocusStatePlayground: View {
     @State var textA = ""
     @State var textB = ""
+    @State var textC = ""
 
     @FocusState var focusBool: Bool
     @FocusState var focusEnum: FocusField?
@@ -18,15 +19,43 @@ struct FocusStatePlayground: View {
                .focused($focusEnum, equals: .textA)
             TextField("textB", text: $textB)
                 .focused($focusEnum, equals: .textB)
+            
+            ChildTextField(
+                title: "textC",
+                value: $textC,
+                focusedField: $focusEnum,
+                assignedFocusField: FocusField.textC
+            )
+            
             Button("Set focus to A via Boolean") { focusBool = true }
             Button("Set focus to A via Enum") { focusEnum = .textA }
             Button("Set focus to B via Enum") { focusEnum = .textB }
+            Button("Set focus to C via Enum") { focusEnum = .textC }
             Button("Nil Enum") { focusEnum = nil }
         }
+    }
+}
+
+struct ChildTextField: View {
+    
+    let title: String
+    @Binding var value: String
+    
+    #if !SKIP
+    @FocusState.Binding var focusedField: FocusField?
+    #else
+    @Binding var focusedField: FocusField?
+    #endif
+    let assignedFocusField: FocusField
+    
+    var body: some View {
+        TextField(title, text: $value)
+            .focused($focusedField, equals: assignedFocusField)
     }
 }
 
 enum FocusField: Int {
     case textA
     case textB
+    case textC
 }

--- a/Sources/Showcase/Resources/Localizable.xcstrings
+++ b/Sources/Showcase/Resources/Localizable.xcstrings
@@ -2247,6 +2247,9 @@
     "Set focus to B via Enum" : {
 
     },
+    "Set focus to C via Enum" : {
+
+    },
     "Settings" : {
       "localizations" : {
         "de" : {


### PR DESCRIPTION
This adds an example to the `FocusStatePlayground` that shows how `@FocusState.Binding` can be replaced with a normal `@Binding` so that `@FocusState` variables can be passed to child views.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [ ] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

