### PR TITLE
Add Preference playground

### DIFF
--- a/Sources/Showcase/PlaygroundListView.swift
+++ b/Sources/Showcase/PlaygroundListView.swift
@@ -45,6 +45,7 @@ enum PlaygroundType: CaseIterable, View {
     case pasteboard
     case picker
     case progressView
+    case preference
     case redacted
     case safeArea
     case scenePhase
@@ -158,6 +159,8 @@ enum PlaygroundType: CaseIterable, View {
             return LocalizedStringResource("Pasteboard")
         case .picker:
             return LocalizedStringResource("Picker")
+        case .preference:
+            return LocalizedStringResource("Preference")
         case .progressView:
             return LocalizedStringResource("ProgressView")
         case .redacted:
@@ -307,6 +310,8 @@ enum PlaygroundType: CaseIterable, View {
             PasteboardPlayground()
         case .picker:
             PickerPlayground()
+        case .preference:
+            PreferencePlayground()
         case .progressView:
             ProgressViewPlayground()
         case .redacted:

--- a/Sources/Showcase/PreferencePlayground.swift
+++ b/Sources/Showcase/PreferencePlayground.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+// TODO tedious double-definition of PreferenceKey
+struct TestPreferenceKey: PreferenceKey {
+    typealias Value = String
+    
+    #if SKIP
+    // SKIP DECLARE: companion object: PreferenceKeyCompanion<String>
+    final class Companion: PreferenceKeyCompanion {
+        let defaultValue = ""
+        func reduce(value: inout String, nextValue: () -> String) {
+            value = nextValue()
+        }
+    }
+    #else
+    static var defaultValue: String = ""
+
+    static func reduce(value: inout String, nextValue: () -> String) {
+        value = nextValue()
+    }
+    #endif
+}
+
+struct ChildView: View {
+    @State private var preferenceValueToSet: String = "Initial Value from Child"
+
+    var body: some View {
+        VStack {
+            Text("Child View")
+            Button("Change Preference to 'Hello World'") {
+                preferenceValueToSet = "Hello World from Child"
+            }
+            Button("Change Preference to 'Goodbye'") {
+                preferenceValueToSet = "Goodbye from Child"
+            }
+        }
+        .preference(key: TestPreferenceKey.self, value: preferenceValueToSet)
+    }
+}
+
+struct PreferencePlayground: View {
+    @State private var receivedPreferenceValue: String = "(No preference received yet)"
+
+    var body: some View {
+        VStack {
+            Text("Parent View")
+            Text("Received from child: \(receivedPreferenceValue)")
+                .padding()
+            
+            ChildView()
+        }
+        .onPreferenceChange(TestPreferenceKey.self) { newValue in
+            print("Preference changed to: \(newValue)")
+            self.receivedPreferenceValue = newValue
+        }
+        .toolbar {
+            PlaygroundSourceLink(file: "PreferencePlayground.swift")
+        }
+    }
+}

--- a/Sources/Showcase/Resources/Localizable.xcstrings
+++ b/Sources/Showcase/Resources/Localizable.xcstrings
@@ -932,6 +932,15 @@
     "CCCC" : {
 
     },
+    "Change Preference to 'Goodbye'" : {
+
+    },
+    "Change Preference to 'Hello World'" : {
+
+    },
+    "Child View" : {
+
+    },
     "Circle" : {
 
     },
@@ -1892,6 +1901,9 @@
     "Paging" : {
 
     },
+    "Parent View" : {
+
+    },
     "Passing a string var does not format as markdown:" : {
 
     },
@@ -1995,6 +2007,9 @@
     "Powered by [Skip](https://skip.tools)" : {
 
     },
+    "Preference" : {
+
+    },
     "Present" : {
 
     },
@@ -2083,6 +2098,9 @@
 
     },
     "Rate" : {
+
+    },
+    "Received from child: %@" : {
 
     },
     "Rectangle" : {


### PR DESCRIPTION
This PR depends on https://github.com/skiptools/skip-ui/pull/210

It also provides an example of how you have to doubly declare preference keys to get them to work. (See the other PR for details.)

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

