### PR TITLE
Merge ShowcaseFuse and ShowcaseLite into a single app

### DIFF
--- a/.github/workflows/skipapp.yml
+++ b/.github/workflows/skipapp.yml
@@ -14,6 +14,20 @@ permissions:
   attestations: write
 
 jobs:
+  export-variants:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Setup Skip"
+        run: |
+          brew install skiptools/skip/skip
+          skip android sdk install
+      - name: "Export Showcase Lite"
+        run: |
+          SKIP_MODE=lite skip export
+      - name: "Export Showcase Fuse"
+        run: |
+          SKIP_MODE=fuse skip export
   call-workflow:
     uses: skiptools/actions/.github/workflows/skip-app.yml@v1
     secrets:

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
     <application
-        android:label="${PRODUCT_NAME}"
+        android:label="Skip Showcase"
         android:name=".AndroidAppMain"
         android:allowBackup="true"
         android:supportsRtl="true"

--- a/Android/app/src/main/kotlin/Main.kt
+++ b/Android/app/src/main/kotlin/Main.kt
@@ -9,7 +9,6 @@ import android.Manifest
 import android.app.Application
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
@@ -21,7 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.core.app.ActivityCompat
 
-internal val logger: SkipLogger = SkipLogger(subsystem = "showcase.app", category = "ShowcaseApp")
+internal val logger: SkipLogger = SkipLogger(subsystem = "showcase", category = "Showcase")
 
 /// AndroidAppMain is the `android.app.Application` entry point, and must match `application android:name` in the AndroidMainfest.xml file.
 open class AndroidAppMain: Application {
@@ -69,12 +68,34 @@ open class MainActivity: AppCompatActivity {
         //ActivityCompat.requestPermissions(self, permissions.toTypedArray(), requestTag)
     }
 
-    override fun onSaveInstanceState(outState: android.os.Bundle): Unit = super.onSaveInstanceState(outState)
+    override fun onStart() {
+        super.onStart()
+        ShowcaseAppDelegate.shared.onStart()
+    }
 
-    override fun onRestoreInstanceState(bundle: android.os.Bundle) {
-        // Usually you restore your state in onCreate(). It is possible to restore it in onRestoreInstanceState() as well, but not very common. (onRestoreInstanceState() is called after onStart(), whereas onCreate() is called before onStart().
-        logger.info("onRestoreInstanceState")
-        super.onRestoreInstanceState(bundle)
+    override fun onResume() {
+        super.onResume()
+        ShowcaseAppDelegate.shared.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        ShowcaseAppDelegate.shared.onPause()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        ShowcaseAppDelegate.shared.onStop()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        ShowcaseAppDelegate.shared.onDestroy()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        ShowcaseAppDelegate.shared.onLowMemory()
     }
 
     override fun onRestart() {
@@ -82,29 +103,12 @@ open class MainActivity: AppCompatActivity {
         super.onRestart()
     }
 
-    override fun onStart() {
-        logger.info("onStart")
-        super.onStart()
-    }
+    override fun onSaveInstanceState(outState: android.os.Bundle): Unit = super.onSaveInstanceState(outState)
 
-    override fun onResume() {
-        logger.info("onResume")
-        super.onResume()
-    }
-
-    override fun onPause() {
-        logger.info("onPause")
-        super.onPause()
-    }
-
-    override fun onStop() {
-        logger.info("onStop")
-        super.onStop()
-    }
-
-    override fun onDestroy() {
-        logger.info("onDestroy")
-        super.onDestroy()
+    override fun onRestoreInstanceState(bundle: android.os.Bundle) {
+        // Usually you restore your state in onCreate(). It is possible to restore it in onRestoreInstanceState() as well, but not very common. (onRestoreInstanceState() is called after onStart(), whereas onCreate() is called before onStart().
+        logger.info("onRestoreInstanceState")
+        super.onRestoreInstanceState(bundle)
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: kotlin.Array<String>, grantResults: IntArray) {
@@ -122,7 +126,7 @@ internal fun PresentationRootView(context: ComposeContext) {
     PresentationRoot(defaultColorScheme = colorScheme, context = context) { ctx ->
         val contentContext = ctx.content()
         Box(modifier = ctx.modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            RootView().Compose(context = contentContext)
+            ShowcaseRootView().Compose(context = contentContext)
         }
     }
 }

--- a/Darwin/Showcase.xcconfig
+++ b/Darwin/Showcase.xcconfig
@@ -13,8 +13,9 @@ INFOPLIST_FILE = Info.plist
 GENERATE_INFOPLIST_FILE = YES
 
 // The user-visible name of the app (localizable)
-//INFOPLIST_KEY_CFBundleDisplayName = App Name
+INFOPLIST_KEY_CFBundleDisplayName = Skip Showcase
 INFOPLIST_KEY_LSApplicationCategoryType = public.app-category.utilities
+//INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "This app uses your location to …"
 
 // iOS-specific Info.plist property keys
 INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphone*] = YES
@@ -38,6 +39,7 @@ MACOSX_DEPLOYMENT_TARGET = 14.0
 TARGETED_DEVICE_FAMILY = 1
 
 SUPPORTS_MACCATALYST = NO
+SWIFT_EMIT_LOC_STRINGS = YES
 
 // the name of the product module; this can be anything, but cannot conflict with any Swift module names
 PRODUCT_MODULE_NAME = $(PRODUCT_NAME:c99extidentifier)App
@@ -48,7 +50,7 @@ PRODUCT_MODULE_NAME = $(PRODUCT_NAME:c99extidentifier)App
 SDKROOT = auto
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx
 SWIFT_EMIT_LOC_STRINGS = YES
-SWIFT_VERSION = 6.0
+SWIFT_VERSION = 6
 
 // Development team ID for on-device testing
 CODE_SIGNING_REQUIRED = NO
@@ -61,5 +63,3 @@ DEVELOPMENT_TEAM[config=Release] = 25KG25YA3R
 CODE_SIGN_IDENTITY[config=Release] = iPhone Distribution: The App Fair Project Inc (25KG25YA3R)
 CODE_SIGN_STYLE[config=Release] = Manual
 PROVISIONING_PROFILE_SPECIFIER[config=Release] = org.appfair.app.Showcase
-
-

--- a/Darwin/Showcase.xcodeproj/project.pbxproj
+++ b/Darwin/Showcase.xcodeproj/project.pbxproj
@@ -8,8 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		490010192BACD83F0000DE33 /* protest_guerrilla.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 490010182BACD83F0000DE33 /* protest_guerrilla.ttf */; };
-		49231BAC2AC5BCEF00F98ADF /* ShowcaseApp in Frameworks */ = {isa = PBXBuildFile; productRef = 49231BAB2AC5BCEF00F98ADF /* ShowcaseApp */; };
-		49231BAD2AC5BCEF00F98ADF /* ShowcaseApp in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 49231BAB2AC5BCEF00F98ADF /* ShowcaseApp */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		498432B42E8080020035BBFA /* Showcase in Frameworks */ = {isa = PBXBuildFile; productRef = 498432B32E8080020035BBFA /* Showcase */; };
+		498432B52E8080020035BBFA /* Showcase in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 498432B32E8080020035BBFA /* Showcase */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		499CD43B2AC5B799001AE8D8 /* Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F90C2B2A52156200F06D93 /* Main.swift */; };
 		499CD4402AC5B799001AE8D8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 49F90C2F2A52156300F06D93 /* Assets.xcassets */; };
 		49DAAD422D2F51F60086DB92 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 49DAAD412D2F51F60086DB92 /* Localizable.xcstrings */; };
@@ -22,7 +22,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				49231BAD2AC5BCEF00F98ADF /* ShowcaseApp in Embed Frameworks */,
+				498432B52E8080020035BBFA /* Showcase in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -49,7 +49,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				49231BAC2AC5BCEF00F98ADF /* ShowcaseApp in Frameworks */,
+				498432B42E8080020035BBFA /* Showcase in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -62,6 +62,13 @@
 				490A40BF2B37A3C300275405 /* Showcase.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		498432B22E8080020035BBFA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		49AB54462B066A7E007B79B2 /* SkipStone */ = {
@@ -82,6 +89,7 @@
 				493609562A6B7EAE00C401E2 /* Showcase */,
 				49F90C2A2A52156200F06D93 /* App */,
 				49AB54462B066A7E007B79B2 /* SkipStone */,
+				498432B22E8080020035BBFA /* Frameworks */,
 				490A40C02B37A3C300275405 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -117,7 +125,7 @@
 			);
 			name = Showcase;
 			packageProductDependencies = (
-				49231BAB2AC5BCEF00F98ADF /* ShowcaseApp */,
+				498432B32E8080020035BBFA /* Showcase */,
 			);
 			productName = App;
 			productReference = 490A40BF2B37A3C300275405 /* Showcase.app */;
@@ -288,9 +296,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		49231BAB2AC5BCEF00F98ADF /* ShowcaseApp */ = {
+		498432B32E8080020035BBFA /* Showcase */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = ShowcaseApp;
+			productName = Showcase;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Darwin/Showcase.xcodeproj/xcshareddata/xcschemes/Showcase App.xcscheme
+++ b/Darwin/Showcase.xcodeproj/xcshareddata/xcschemes/Showcase App.xcscheme
@@ -50,6 +50,13 @@
             ReferencedContainer = "container:Showcase.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "SKIP_COMMAND_OVERRIDE"
+            value = "/Users/marc/Library/Developer/Xcode/DerivedData/Skip-Everything-aqywrhrzhkbvfseiqgxuufbdwdft/Build/Products/Debug/skip"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Darwin/Sources/Main.swift
+++ b/Darwin/Sources/Main.swift
@@ -1,7 +1,65 @@
-// SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
 import SwiftUI
 import Showcase
 
 /// The entry point to the app simply loads the App implementation from SPM module.
-@main struct AppMain: App, ShowcaseApp {
+@main struct AppMain: App {
+    @AppDelegateAdaptor(AppMainDelegate.self) var appDelegate
+    @Environment(\.scenePhase) private var scenePhase
+
+    var body: some Scene {
+        WindowGroup {
+            ShowcaseRootView()
+        }
+        .onChange(of: scenePhase) { oldPhase, newPhase in
+            switch newPhase {
+            case .active:
+                AppDelegate.shared.onResume()
+            case .inactive:
+                AppDelegate.shared.onPause()
+            case .background:
+                AppDelegate.shared.onStop()
+            @unknown default:
+                print("unknown app phase: \(newPhase)")
+            }
+        }
+    }
+}
+
+typealias AppDelegate = ShowcaseAppDelegate
+#if canImport(UIKit)
+typealias AppDelegateAdaptor = UIApplicationDelegateAdaptor
+typealias AppMainDelegateBase = UIApplicationDelegate
+typealias AppType = UIApplication
+#elseif canImport(AppKit)
+typealias AppDelegateAdaptor = NSApplicationDelegateAdaptor
+typealias AppMainDelegateBase = NSApplicationDelegate
+typealias AppType = NSApplication
+#endif
+
+class AppMainDelegate: NSObject, AppMainDelegateBase {
+    @MainActor let application = AppType.shared
+
+    #if canImport(UIKit)
+    func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        AppDelegate.shared.onStart()
+        return true
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        AppDelegate.shared.onDestroy()
+    }
+
+    func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
+        AppDelegate.shared.onLowMemory()
+    }
+    #elseif canImport(AppKit)
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        AppDelegate.shared.onStart()
+    }
+
+    func applicationWillTerminate(_ application: Notification) {
+        AppDelegate.shared.onDestroy()
+    }
+    #endif
+
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,16 +1,19 @@
 // swift-tools-version: 6.0
 import PackageDescription
 
+// switch between "lite" (Skip Lite transpiled) and "fuse" (Skip Fuse compiled)
+let SKIP_MODE = Context.environment["SKIP_MODE"] ?? "lite"
+
 let package = Package(
     name: "skipapp-showcase",
     defaultLocalization: "en",
     platforms: [.iOS(.v17), .macOS(.v14), .tvOS(.v17), .watchOS(.v10), .macCatalyst(.v17)],
     products: [
-        .library(name: "ShowcaseApp", type: .dynamic, targets: ["Showcase"]),
+        .library(name: "Showcase", type: .dynamic, targets: ["Showcase"]),
     ],
     dependencies: [
-        .package(url: "https://source.skip.tools/skip.git", from: "1.4.0"),
-        .package(url: "https://source.skip.tools/skip-ui.git", from: "1.26.0"),
+        .package(url: "https://source.skip.tools/skip.git", from: "1.6.21"),
+        SKIP_MODE == "lite" ? .package(url: "https://source.skip.tools/skip-ui.git", from: "1.0.0") : .package(url: "https://source.skip.tools/skip-fuse-ui.git", from: "1.0.0"),
         .package(url: "https://source.skip.tools/skip-av.git", "0.0.0"..<"2.0.0"),
         .package(url: "https://source.skip.tools/skip-kit.git", "0.0.0"..<"2.0.0"),
         .package(url: "https://source.skip.tools/skip-sql.git", "0.12.1"..<"2.0.0"),
@@ -21,10 +24,10 @@ let package = Package(
     ],
     targets: [
         .target(name: "Showcase", dependencies: [
-            .product(name: "SkipUI", package: "skip-ui"),
+            SKIP_MODE == "lite" ? .product(name: "SkipUI", package: "skip-ui") : .product(name: "SkipFuseUI", package: "skip-fuse-ui"),
             .product(name: "SkipAV", package: "skip-av"),
             .product(name: "SkipKit", package: "skip-kit"),
-            .product(name: "SkipSQL", package: "skip-sql"),
+            .product(name: "SkipSQLPlus", package: "skip-sql"),
             .product(name: "SkipWeb", package: "skip-web"),
             .product(name: "SkipDevice", package: "skip-device"),
             .product(name: "SkipMotion", package: "skip-motion"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Skip Component Showcase
 
-Showcase is a [Skip Lite](https://skip.tools) app that demonstrates many of the components available in SkipUI.
+Showcase is a [Skip](https://skip.tools) app that demonstrates many of the components available in SkipUI.
 
 [<img src="https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg" alt="Get it on Google Play Store" height="80">](https://play.google.com/store/apps/details?id=org.appfair.app.Showcase) [<img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg" alt="Get it on App Store" height="80">](https://apps.apple.com/us/app/skip-showcase/id6474885022)
 
@@ -24,14 +24,25 @@ $ git clone https://github.com/skiptools/skipapp-showcase.git
 5. Select and Run the `Showcase` target with an iOS simulator destination; the app will build and run side-by-side on the iOS simulator and Android emulator.
 
 
-## Project
+## Development
 
-This project was initialized with the command:
+The Showcase app supports both the Skip Lite transpiled mode as well as the Skip Fuse compiled mode.
+
+You can switch between the modes you use to develop by changing the default value of the `SKIP_MODE` constant in the `Package.swift` file between "fuse" and "lite".
+
+```swift
+let SKIP_MODE = Context.environment["SKIP_MODE"] ?? "lite" // change to "fuse"
+```
+
+Additionally, you need to switch the mode of the `Source/Showcase/Skip/skip.yml` file from 'transpiled' to 'native':
 
 ```
-skip init --no-module-tests --no-build --icon-color=8E8E93 --free --zero --appid=skip.showcase.App skipapp-showcase Showcase
+skip:
+  mode: 'transpiled'
+  #mode: 'native'
 ```
 
+Once you make this change, re-building and running the project will use SkipFuse mode rather than SkipLite.
 
 ## Testing
 

--- a/Skip.env
+++ b/Skip.env
@@ -8,14 +8,13 @@ SKIP_PROJECT_NAME = skipapp-showcase
 PRODUCT_NAME = Showcase
 
 // PRODUCT_BUNDLE_IDENTIFIER is the unique id for both the iOS and Android app
-PRODUCT_BUNDLE_IDENTIFIER = org.appfair.app.ShowcaseLite
+PRODUCT_BUNDLE_IDENTIFIER = org.appfair.app.Showcase
 
 // The semantic version of the app
-MARKETING_VERSION = 1.12.2
+MARKETING_VERSION = 2.1.1
 
 // The build number specifying the internal app version
-CURRENT_PROJECT_VERSION = 197
+CURRENT_PROJECT_VERSION = 208
 
 // The package name for the Android entry point, referenced by the AndroidManifest.xml
 ANDROID_PACKAGE_NAME = showcase.module
-

--- a/Sources/Showcase/AboutView.swift
+++ b/Sources/Showcase/AboutView.swift
@@ -1,4 +1,5 @@
 // Copyright 2023–2025 Skip
+import Foundation
 import SwiftUI
 
 /// Information and links for Skip and the Showcase app.
@@ -13,7 +14,7 @@ struct AboutView: View {
                     .padding()
                 LinkDivider()
                 Link(destination: URL(string: "https://skip.tools")!) {
-                    LinkLabel(text: NSLocalizedString("Skip Technology", bundle: .module, comment: "localized technology title"))
+                    LinkLabel(text: NSLocalizedString("Skip Technology", bundle: .module, comment: "Localized technology title"))
                 }
                 LinkDivider()
                 Link(destination: URL(string: showcaseSourceURLString + "DOWNLOAD.md")!) {

--- a/Sources/Showcase/AccessibilityPlayground.swift
+++ b/Sources/Showcase/AccessibilityPlayground.swift
@@ -9,15 +9,16 @@ struct AccessibilityPlayground: View {
             VStack(spacing: 16) {
                 Text("Simulate a custom control with an accessibility label, value, and traits:")
                 Text(isOn ? "+" : "-").font(.largeTitle)
-                    .onTapGesture { isOn = !isOn }
                     .accessibilityLabel("My custom control")
                     .accessibilityValue(isOn ? "On" : "Off")
                     .accessibilityAddTraits(.isButton) // Use .isToggle on iOS 17+
-                
+                    .onTapGesture { isOn = !isOn }
+
                 Divider()
                 
                 Text("Hide the following element from accessibility:")
                 Text("Hidden").font(.largeTitle)
+                    .accessibilityHeading(.h2)
                     .accessibilityHidden(true)
             }
             .padding()

--- a/Sources/Showcase/AlertPlayground.swift
+++ b/Sources/Showcase/AlertPlayground.swift
@@ -1,4 +1,5 @@
 // Copyright 2023–2025 Skip
+import Foundation
 import SwiftUI
 
 struct AlertPlayground: View {
@@ -20,34 +21,29 @@ struct AlertPlayground: View {
     var body: some View {
         VStack(spacing: 16) {
             Text(value).bold()
-            Group {
-                Button("Title") {
-                    titleIsPresented = true
-                }
-                Button("Title + Message") {
-                    titleMessageIsPresented = true
-                }
-                Button("Two Buttons") {
-                    twoButtonsIsPresented = true
-                }
-                Button("Three Buttons") {
-                    threeButtonsIsPresented = true
-                }
-                Button("Five Buttons") {
-                    fiveButtonsIsPresented = true
-                }
+            Button("Title") {
+                titleIsPresented = true
+            }
+            Button("Title + Message") {
+                titleMessageIsPresented = true
+            }
+            Button("Two Buttons") {
+                twoButtonsIsPresented = true
+            }
+            Button("Three Buttons") {
+                threeButtonsIsPresented = true
+            }
+            Button("Five Buttons") {
+                fiveButtonsIsPresented = true
             }
             Divider()
-            Group {
-                Button("Text Field") {
-                    textFieldIsPresented = true
-                }
-                Button("Secure Field") {
-                    secureFieldIsPresented = true
-                }
+            Button("Text Field") {
+                textFieldIsPresented = true
+            }
+            Button("Secure Field") {
+                secureFieldIsPresented = true
             }
             Divider()
-//            Group {
 //                Text("Present with error")
 //                Button("Error: \(String(describing: error))") {
 //                    error = AlertPlaygroundError.testError
@@ -58,23 +54,20 @@ struct AlertPlayground: View {
 //                Button("Present") {
 //                    errorIsPresented = true
 //                }
-//            }
 //            Divider()
-            Group {
-                Text("Present with data")
-                Button("Data: \(String(describing: data))") {
-                    if data == nil {
-                        data = 1
-                    } else {
-                        data = data! + 1
-                    }
+            Text("Present with data")
+            Button("Data: \(String(describing: data))") {
+                if data == nil {
+                    data = 1
+                } else {
+                    data = data! + 1
                 }
-                Button("Nil data") {
-                    data = nil
-                }
-                Button("Present") {
-                    dataIsPresented = true
-                }
+            }
+            Button("Nil data") {
+                data = nil
+            }
+            Button("Present") {
+                dataIsPresented = true
             }
         }
         .padding()

--- a/Sources/Showcase/AudioPlayground.swift
+++ b/Sources/Showcase/AudioPlayground.swift
@@ -1,12 +1,17 @@
 // Copyright 2023–2025 Skip
 import SwiftUI
 #if os(macOS)
+#elseif canImport(SkipAV)
+import SkipAV
 #else
 import AVFoundation
 #endif
+#if canImport(SkipFuse) && !SKIP
+import SkipFuse
+#endif
 
 struct AudioPlayground: View {
-    #if os(macOS)
+    #if !os(iOS) || !SKIP // Skip Lite only
     #else
     @State var isRecording: Bool = false
     @State var errorMessage: String? = nil
@@ -29,8 +34,8 @@ struct AudioPlayground: View {
     #endif
 
     var body: some View {
-        #if os(macOS)
-        Text("Not supported on macOS")
+        #if !os(iOS) || !SKIP // Skip Lite only
+        Text("Not supported on macOS or Skip Fuse")
         #else
         return VStack(spacing: 20) {
             Button(action: {
@@ -72,7 +77,7 @@ struct AudioPlayground: View {
         #endif
     }
     
-    #if os(macOS)
+    #if !os(iOS) || !SKIP // Skip Lite only
     #else
     func startRecording() {
         do {

--- a/Sources/Showcase/ColorPlayground.swift
+++ b/Sources/Showcase/ColorPlayground.swift
@@ -31,7 +31,10 @@ struct ColorPlayground: View {
                 colorRow(label: Text("Secondary"), color: .secondary)
                 colorRow(label: Text("\"CustomRed\""), color: Color("CustomRed", bundle: .module))
                 colorRow(label: Text("\"SystemBlue\""), color: Color("SystemBlue", bundle: .module))
+                #if SKIP // Skip Lite only
+                // TODO: #colorLiteral support via macro?
                 colorRow(label: Text("#colorLiteral"), color: Color(#colorLiteral(red: 0.2588235438, green: 0.7568627596, blue: 0.9686274529, alpha: 1)))
+                #endif
             }
             .padding()
         }

--- a/Sources/Showcase/ColorSchemePlayground.swift
+++ b/Sources/Showcase/ColorSchemePlayground.swift
@@ -42,7 +42,7 @@ struct ColorSchemePlayground: View {
     }
 }
 
-private struct ColorSchemeSheetView: View {
+struct ColorSchemeSheetView: View {
     @Environment(\.dismiss) var dismiss
     @State var preferredColorScheme = ""
 

--- a/Sources/Showcase/ComposePlayground.swift
+++ b/Sources/Showcase/ComposePlayground.swift
@@ -4,12 +4,9 @@ import SwiftUI
 struct ComposePlayground: View {
     var body: some View {
         Group {
-            #if SKIP
-            ComposeView { context in
-                androidx.compose.foundation.layout.Column(modifier: context.modifier) {
-                    androidx.compose.material3.Text("Hello from Compose!")
-                    androidx.compose.material3.Text("This content is rendered with Compose code using ComposeView")
-                }
+            #if os(Android)
+            ComposeView {
+                MessageComposer(message: Text("Welcome"), textColor: .red)
             }
             .border(.blue)
             #else
@@ -23,3 +20,18 @@ struct ComposePlayground: View {
     }
 }
 
+#if SKIP
+
+struct MessageComposer : ContentComposer {
+    let message: Text
+    let textColor: Color
+
+    @Composable override func Compose(context: ComposeContext) {
+        androidx.compose.foundation.layout.Column(modifier: context.modifier) {
+            androidx.compose.material3.Text(message.localizedTextString(), color: textColor.asComposeColor())
+            androidx.compose.material3.Text("This content is rendered with Compose code using ComposeView")
+        }
+    }
+}
+
+#endif

--- a/Sources/Showcase/Constants.swift
+++ b/Sources/Showcase/Constants.swift
@@ -1,0 +1,5 @@
+// Copyright 2023–2025 Skip
+
+/// URL string of the source this app.
+let showcaseSourceURLString = "https://source.skip.tools/skipapp-showcase/tree/main/"
+let playgroundPath = "Sources/Showcase/"

--- a/Sources/Showcase/ContentView.swift
+++ b/Sources/Showcase/ContentView.swift
@@ -34,7 +34,3 @@ struct ContentView: View {
         .preferredColorScheme(appearance == "dark" ? .dark : appearance == "light" ? .light : nil)
     }
 }
-
-#Preview {
-    ContentView()
-}

--- a/Sources/Showcase/DatePickerPlayground.swift
+++ b/Sources/Showcase/DatePickerPlayground.swift
@@ -1,4 +1,5 @@
 // Copyright 2023–2025 Skip
+import Foundation
 import SwiftUI
 
 struct DatePickerPlayground: View {

--- a/Sources/Showcase/EnvironmentPlayground.swift
+++ b/Sources/Showcase/EnvironmentPlayground.swift
@@ -16,8 +16,8 @@ struct EnvironmentPlayground: View {
                     .environment(\.environmentPlaygroundCustomKey, "Custom!")
             }
         }
-        .onChange(of: tapCountObservable.tapCount) {
-            logger.log("onChange(of: tapCountObservable.tapCount): \($0)")
+        .onChange(of: tapCountObservable.tapCount) { oldValue, newValue in
+            logger.log("onChange(of: tapCountObservable.tapCount): \(newValue)")
         }
         .toolbar {
             PlaygroundSourceLink(file: "EnvironmentPlayground.swift")

--- a/Sources/Showcase/GesturePlayground.swift
+++ b/Sources/Showcase/GesturePlayground.swift
@@ -7,6 +7,9 @@ struct GesturePlayground: View {
     @State var longPressCount = 0
     @State var dragOffset: CGSize = .zero
     @State var globalDragOffset: CGSize = .zero
+    #if !SKIP // Skip Fuse only
+    @GestureState(initialValue: .zero, resetTransaction: Transaction(animation: .default)) var gestureStateDragOffset: CGSize
+    #endif
     @State var magnification: CGFloat = 1.0
     @State var rotation: Angle = .degrees(0.0)
     @State var isTouchDown = false
@@ -110,6 +113,22 @@ struct GesturePlayground: View {
                                 .onEnded { _ in withAnimation { globalDragOffset = .zero } }
                         )
                 }
+                #if !SKIP // Skip Fuse only
+                HStack {
+                    Text("GestureState Drag")
+                    Spacer()
+                    Color.red
+                        .frame(width: 150, height: 150)
+                        .offset(gestureStateDragOffset)
+                        .gesture(
+                            DragGesture()
+                                .updating($gestureStateDragOffset) { val, state, _ in
+                                    state = val.translation
+                                    logger.info("Drag position: (\(val.location.x), \(val.location.y))")
+                                }
+                        )
+                }
+                #endif
                 HStack {
                     Text("Touch")
                     Spacer()
@@ -122,6 +141,18 @@ struct GesturePlayground: View {
                                 .onEnded { _ in isTouchDown = false }
                         )
                 }
+                #if !SKIP // Skip Fuse only
+                HStack {
+                    Text("Disabled tap: (\(Int(tapPosition.x)), \(Int(tapPosition.y)))")
+                    Spacer()
+                    Color.red
+                        .frame(width: 150, height: 150)
+                        .onTapGesture {
+                            tapPosition = $0
+                        }
+                        .disabled(true)
+                }
+                #endif
                 VStack {
                     Text("Magnify")
                     Color.red
@@ -149,7 +180,7 @@ struct GesturePlayground: View {
                         )
                 }
                 VStack {
-                    VStack {
+                    VStack(alignment: .leading) {
                         Text("Tap: (\(Int(combinedTapPosition.x)), \(Int(combinedTapPosition.y)))")
                         Text("Double tap: (\(Int(combinedDoubleTapPosition.x)), \(Int(combinedDoubleTapPosition.y)))")
                         Text("Long press: \(combinedLongPressCount)")

--- a/Sources/Showcase/GridPlayground.swift
+++ b/Sources/Showcase/GridPlayground.swift
@@ -70,7 +70,7 @@ struct GridPlayground: View {
     }
 }
 
-private struct LazyVGridAdaptiveView: View {
+struct LazyVGridAdaptiveView: View {
     let count: Int
 
     var body: some View {
@@ -82,7 +82,7 @@ private struct LazyVGridAdaptiveView: View {
     }
 }
 
-private struct LazyVGridFlexibleView: View {
+struct LazyVGridFlexibleView: View {
     var body: some View {
         ScrollView {
             LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]) {
@@ -95,7 +95,7 @@ private struct LazyVGridFlexibleView: View {
     }
 }
 
-private struct LazyVGridFixedView: View {
+struct LazyVGridFixedView: View {
     var body: some View {
         ScrollView {
             LazyVGrid(columns: [GridItem(.fixed(80)), GridItem(.fixed(80)), GridItem(.fixed(80)), GridItem(.fixed(80))]) {
@@ -110,7 +110,7 @@ private struct LazyVGridFixedView: View {
     }
 }
 
-private struct LazyVGridTrailingView: View {
+struct LazyVGridTrailingView: View {
     var body: some View {
         ScrollView {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 80), alignment: .trailing)]) {
@@ -126,7 +126,7 @@ private struct LazyVGridTrailingView: View {
     }
 }
 
-private struct LazyVGridSectionedView: View {
+struct LazyVGridSectionedView: View {
     var body: some View {
         ScrollView {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 80))]) {
@@ -145,7 +145,7 @@ private struct LazyVGridSectionedView: View {
     }
 }
 
-private struct LazyVGridRefreshableView: View {
+struct LazyVGridRefreshableView: View {
     var body: some View {
         ScrollView {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 80))]) {
@@ -158,7 +158,7 @@ private struct LazyVGridRefreshableView: View {
     }
 }
 
-private struct LazyHGridAdaptiveView: View {
+struct LazyHGridAdaptiveView: View {
     let count: Int
 
     var body: some View {
@@ -170,7 +170,7 @@ private struct LazyHGridAdaptiveView: View {
     }
 }
 
-private struct LazyHGridFlexibleView: View {
+struct LazyHGridFlexibleView: View {
     var body: some View {
         ScrollView(.horizontal) {
             LazyHGrid(rows: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]) {
@@ -183,7 +183,7 @@ private struct LazyHGridFlexibleView: View {
     }
 }
 
-private struct LazyHGridFixedView: View {
+struct LazyHGridFixedView: View {
     var body: some View {
         ScrollView(.horizontal) {
             LazyHGrid(rows: [GridItem(.fixed(80)), GridItem(.fixed(80)), GridItem(.fixed(80)), GridItem(.fixed(80))]) {
@@ -199,7 +199,7 @@ private struct LazyHGridFixedView: View {
     }
 }
 
-private struct LazyHGridBottomView: View {
+struct LazyHGridBottomView: View {
     var body: some View {
         ScrollView(.horizontal) {
             LazyHGrid(rows: [GridItem(.adaptive(minimum: 80), alignment: .bottom)]) {
@@ -215,7 +215,7 @@ private struct LazyHGridBottomView: View {
     }
 }
 
-private struct LazyHGridSectionedView: View {
+struct LazyHGridSectionedView: View {
     var body: some View {
         ScrollView(.horizontal) {
             LazyHGrid(rows: [GridItem(.adaptive(minimum: 80))]) {
@@ -234,7 +234,7 @@ private struct LazyHGridSectionedView: View {
     }
 }
 
-private struct LazyVGridPaddingView: View {
+struct LazyVGridPaddingView: View {
     var body: some View {
         ScrollView {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 80))]) {

--- a/Sources/Showcase/HapticFeedbackPlayground.swift
+++ b/Sources/Showcase/HapticFeedbackPlayground.swift
@@ -3,8 +3,8 @@ import SwiftUI
 
 @available(macOS 14.0, iOS 17.0, *)
 struct HapticFeedbackPlayground: View {
-    @State private var feedbackValue = 0.0
-    @State private var feedbackType = FeedbackType.success
+    @State var feedbackValue = 0.0
+    @State var feedbackType = FeedbackType.success
 
     enum FeedbackType: String, CaseIterable {
         case success
@@ -52,6 +52,7 @@ struct HapticFeedbackPlayground: View {
             }
         }
     }
+
     var body: some View {
         VStack {
             Spacer()

--- a/Sources/Showcase/ImagePlayground.swift
+++ b/Sources/Showcase/ImagePlayground.swift
@@ -322,7 +322,7 @@ struct ImagePlayground: View {
     }
 }
 
-private struct ImagePlaygroundPagerView: View {
+struct ImagePlaygroundPagerView: View {
     var body: some View {
         GeometryReader { proxy in
             ScrollView(.horizontal) {
@@ -346,7 +346,7 @@ private struct ImagePlaygroundPagerView: View {
 
 struct PagingModifier: ViewModifier {
     func body(content: Content) -> some View {
-        #if !SKIP
+        #if !os(Android)
         if #available(iOS 17.0, macOS 14.0, *) {
             content
                 .scrollTargetBehavior(.paging)
@@ -359,7 +359,7 @@ struct PagingModifier: ViewModifier {
     }
 }
 
-private struct ImagePlaygroundComplexLayoutView: View {
+struct ImagePlaygroundComplexLayoutView: View {
     let imageName: String
 
     var body: some View {

--- a/Sources/Showcase/LinkPlayground.swift
+++ b/Sources/Showcase/LinkPlayground.swift
@@ -1,4 +1,5 @@
 // Copyright 2023–2025 Skip
+import Foundation
 import SwiftUI
 
 struct LinkPlayground: View {

--- a/Sources/Showcase/LocalizationPlayground.swift
+++ b/Sources/Showcase/LocalizationPlayground.swift
@@ -21,6 +21,7 @@ struct LocalizationPlayground: View {
 struct LocalizationPreview: View {
     @Environment(\.locale) var currentLocale
     @State var date = Date.now
+    let skipper = "Skipper"
 
     func formatter(dateStyle: DateFormatter.Style, timeStyle: DateFormatter.Style) -> DateFormatter {
         let fmt = DateFormatter()
@@ -35,6 +36,10 @@ struct LocalizationPreview: View {
             Text("Welcome")
                 .font(.largeTitle)
             Text(LocalizedStringResource("Welcome"))
+                .font(.title)
+            Text("Welcome \(skipper)")
+                .font(.largeTitle)
+            Text(LocalizedStringResource("Welcome \(skipper)"))
                 .font(.title)
 
             Divider()

--- a/Sources/Showcase/LottiePlayground.swift
+++ b/Sources/Showcase/LottiePlayground.swift
@@ -1,4 +1,5 @@
 // Copyright 2023–2025 Skip
+import Foundation
 import SwiftUI
 import SkipMotion
 

--- a/Sources/Showcase/MapPlayground.swift
+++ b/Sources/Showcase/MapPlayground.swift
@@ -1,13 +1,8 @@
 // Copyright 2023–2025 Skip
-import SwiftUI
-#if !SKIP
+#if canImport(MapKit)
 import MapKit
-#else
-// add dependency in skip.yml: implementation("com.google.maps.android:maps-compose:6.4.1")
-import com.google.maps.android.compose.__
-import com.google.android.gms.maps.model.CameraPosition
-import com.google.android.gms.maps.model.LatLng
 #endif
+import SwiftUI
 
 struct MapPlayground: View {
     var body: some View {
@@ -20,7 +15,17 @@ struct MapView : View {
     let longitude: Double
 
     var body: some View {
-        #if !SKIP
+        #if SKIP
+        // on Android platforms, we use com.google.maps.android.compose.GoogleMap within in a ComposeView
+        ComposeView { ctx in
+            GoogleMap(cameraPositionState: rememberCameraPositionState {
+                position = CameraPosition.fromLatLngZoom(LatLng(latitude, longitude), Float(12.0))
+            })
+        }
+        #elseif os(Android)
+        // on Android platforms, we use com.google.maps.android.compose.GoogleMap within in a ComposeView
+        ComposeView { MapComposer(latitude: latitude, longitude: longitude) }
+        #else
         // on Darwin platforms, we use the new SwiftUI Map type
         if #available(iOS 17.0, macOS 14.0, *) {
             Map(initialPosition: .region(MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: latitude, longitude: longitude), span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1))))
@@ -28,13 +33,25 @@ struct MapView : View {
             Text("Map requires iOS 17")
                 .font(.title)
         }
-        #else
-        // on Android platforms, we use com.google.maps.android.compose.GoogleMap within in a ComposeView
-        ComposeView { ctx in
-            GoogleMap(cameraPositionState: rememberCameraPositionState {
-                position = CameraPosition.fromLatLngZoom(LatLng(latitude, longitude), Float(12.0))
-            })
-        }
         #endif
     }
 }
+
+#if SKIP
+// skip.yml: implementation("com.google.maps.android:maps-compose:4.3.3")
+import com.google.maps.android.compose.__
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+
+struct MapComposer : ContentComposer {
+    let latitude: Double
+    let longitude: Double
+
+    @Composable func Compose(context: ComposeContext) {
+        GoogleMap(cameraPositionState: rememberCameraPositionState {
+            position = CameraPosition.fromLatLngZoom(LatLng(latitude, longitude), Float(12.0))
+        })
+    }
+}
+
+#endif

--- a/Sources/Showcase/ModifierPlayground.swift
+++ b/Sources/Showcase/ModifierPlayground.swift
@@ -1,9 +1,5 @@
 // Copyright 2023–2025 Skip
 import SwiftUI
-#if SKIP
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.fillMaxWidth
-#endif
 
 struct ModifierPlayground: View {
     var body: some View {
@@ -16,11 +12,15 @@ struct ModifierPlayground: View {
             Text("This is text that uses a function that returns EmptyModifier()")
                 .modifier(someModifier)
             Text(".composeModifier()")
-                #if SKIP
-                .composeModifier {
-                    $0.background(androidx.compose.ui.graphics.Color.Yellow).fillMaxWidth()
-                }
-                #endif
+//                #if os(Android)
+//                .composeModifier {
+//                    #if SKIP // Skip Lite mode
+//                    $0.background(androidx.compose.ui.graphics.Color.Yellow).fillMaxWidth()
+//                    #elseif !SKIP_BRIDGE // Skip Fuse mode
+//                    BackgroundModifier()
+//                    #endif
+//                }
+//                #endif
         }
         .padding()
     }
@@ -52,3 +52,16 @@ struct DismissModifier: ViewModifier {
             }
     }
 }
+
+#if SKIP
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+
+struct BackgroundModifier : ContentModifier {
+    func modify(view: any View) -> any View {
+        view.composeModifier {
+            $0.background(androidx.compose.ui.graphics.Color.Yellow).fillMaxWidth()
+        }
+    }
+}
+#endif

--- a/Sources/Showcase/NavigationStackPlayground.swift
+++ b/Sources/Showcase/NavigationStackPlayground.swift
@@ -52,7 +52,7 @@ struct NavigationStackPlayground: View {
     }
 }
 
-private struct PathBindingSheetContentView: View {
+struct PathBindingSheetContentView: View {
     @Environment(\.dismiss) var dismiss
     @State var path: [PathElement] = []
 
@@ -84,7 +84,7 @@ private struct PathBindingSheetContentView: View {
     }
 }
 
-private struct NavigationPathBindingSheetContentView: View {
+struct NavigationPathBindingSheetContentView: View {
     @Environment(\.dismiss) var dismiss
     @State var path = NavigationPath()
 
@@ -136,7 +136,7 @@ struct PathElement: RawRepresentable, Hashable, CustomStringConvertible {
     }
 }
 
-private struct PathElementView: View {
+struct PathElementView: View {
     @Environment(\.dismiss) var dismiss
     let element: PathElement
     @Binding var path: [PathElement]
@@ -183,7 +183,7 @@ private struct PathElementView: View {
     }
 }
 
-private struct NavigationPathElementView: View {
+struct NavigationPathElementView: View {
     @Environment(\.dismiss) var dismiss
     let element: PathElement
     @Binding var path: NavigationPath

--- a/Sources/Showcase/ObservablePlayground.swift
+++ b/Sources/Showcase/ObservablePlayground.swift
@@ -1,14 +1,11 @@
 // Copyright 2023–2025 Skip
 import SwiftUI
-#if canImport(Observation)
-import Observation
-#endif
 
 struct ObservablePlayground: View {
     var body: some View {
         if #available(iOS 17.0, macOS 14.0, *) {
             ObservablesOuterView()
-                .environmentObject(PlaygroundEnvironmentObject(text: "initialEnvironment"))
+                .environment(PlaygroundEnvironmentObject(text: "initialEnvironment"))
                 .toolbar {
                     PlaygroundSourceLink(file: "ObservablePlayground.swift")
                 }
@@ -18,8 +15,9 @@ struct ObservablePlayground: View {
     }
 }
 
-class PlaygroundEnvironmentObject: ObservableObject {
-    @Published var text: String
+@available(iOS 17.0, macOS 14.0, *)
+@Observable class PlaygroundEnvironmentObject {
+    var text: String
     init(text: String) {
         self.text = text
     }
@@ -36,7 +34,7 @@ class PlaygroundEnvironmentObject: ObservableObject {
 @available(iOS 17.0, macOS 14.0, *)
 struct ObservablesOuterView: View {
     @State var stateObject = PlaygroundObservable(text: "initialState")
-    @EnvironmentObject var environmentObject: PlaygroundEnvironmentObject
+    @Environment(PlaygroundEnvironmentObject.self) var environmentObject
     var body: some View {
         VStack {
             Text(stateObject.text)
@@ -52,7 +50,7 @@ struct ObservablesOuterView: View {
 @available(iOS 17.0, macOS 14.0, *)
 struct ObservablesObservableView: View {
     let observable: PlaygroundObservable
-    @EnvironmentObject var environmentObject: PlaygroundEnvironmentObject
+    @Environment(PlaygroundEnvironmentObject.self) var environmentObject
     var body: some View {
         Text(observable.text)
         Text(environmentObject.text)

--- a/Sources/Showcase/PasteboardPlayground.swift
+++ b/Sources/Showcase/PasteboardPlayground.swift
@@ -55,9 +55,10 @@ struct PasteboardPlayground: View {
             }
             .padding()
         }
-        .onReceive(NotificationCenter.default.publisher(for: UIPasteboard.changedNotification), perform: { notification in
-            pasteboardInfo = PasteboardInfo(notification.object as! UIPasteboard)
-        })
+        // TODO: NotificationCenter publisher
+//        .onReceive(NotificationCenter.default.publisher(for: UIPasteboard.changedNotification), perform: { notification in
+//            pasteboardInfo = PasteboardInfo(notification.object as! UIPasteboard)
+//        })
         .toolbar {
             PlaygroundSourceLink(file: "PasteboardPlayground.swift")
         }

--- a/Sources/Showcase/PickerPlayground.swift
+++ b/Sources/Showcase/PickerPlayground.swift
@@ -48,9 +48,13 @@ struct PickerPlayground: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                #if os(Android)
+                #if SKIP
                 .material3SegmentedButton {
                     $0.copy(icon: {})
+                }
+                #elseif os(Android)
+                .composeModifier {
+                    NoIconModifier()
                 }
                 #endif
                 VStack {
@@ -164,3 +168,14 @@ struct PickerPlayground: View {
     }
 }
 
+#if SKIP
+
+struct NoIconModifier : ContentModifier {
+    func modify(view: any View) -> any View {
+        view.material3SegmentedButton {
+            $0.copy(icon: {})
+        }
+    }
+}
+
+#endif

--- a/Sources/Showcase/PlatformHelper.swift
+++ b/Sources/Showcase/PlatformHelper.swift
@@ -1,14 +1,17 @@
 // Copyright 2023–2025 Skip
 import Foundation
+#if canImport(SkipFuse) && !SKIP
+import SkipFuse
+#endif
 
-#if !SKIP
-let isAndroid = false
-#else
+#if os(Android)
 let isAndroid = true
+#else
+let isAndroid = false
 #endif
 
 /// The name of the current app
-let appName = (Bundle.main.infoDictionary?["CFBundleName"] as? String) ?? "Unknown"
+let appName = (Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String) ?? (Bundle.main.infoDictionary?["CFBundleName"] as? String) ?? "Unknown"
 
 /// The current version of the app, using the main bundle's infoDictionary `CFBundleShortVersionString` property on iOS and `android.content.pm.PackageManager` `versionName` on Android.
 let appVersion = (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "0.0.0"

--- a/Sources/Showcase/PlaygroundListView.swift
+++ b/Sources/Showcase/PlaygroundListView.swift
@@ -6,7 +6,7 @@ enum PlaygroundType: CaseIterable, View {
     case accessibility
     case alert
     case animation
-    case audio
+//    case audio
     case background
     case blur
     case border
@@ -67,7 +67,7 @@ enum PlaygroundType: CaseIterable, View {
     case state
     case storage
     case symbol
-    case table
+//    case table
     case tabView
     case text
     case textEditor
@@ -83,157 +83,157 @@ enum PlaygroundType: CaseIterable, View {
     var title: LocalizedStringResource {
         switch self {
         case .accessibility:
-            return LocalizedStringResource("Accessibility")
+            return LocalizedStringResource("Accessibility", comment: "Title of Accessibility playground")
         case .alert:
-            return LocalizedStringResource("Alert")
+            return LocalizedStringResource("Alert", comment: "Title of Alert playground")
         case .animation:
-            return LocalizedStringResource("Animation")
-        case .audio:
-            return LocalizedStringResource("Audio")
+            return LocalizedStringResource("Animation", comment: "Title of Animation playground")
+//        case .audio:
+//            return LocalizedStringResource("Audio")
         case .background:
-            return LocalizedStringResource("Background")
+            return LocalizedStringResource("Background", comment: "Title of Background playground")
         case .blur:
-            return LocalizedStringResource("Blur")
+            return LocalizedStringResource("Blur", comment: "Title of Blur playground")
         case .border:
-            return LocalizedStringResource("Border")
+            return LocalizedStringResource("Border", comment: "Title of Border playground")
         case .button:
-            return LocalizedStringResource("Button")
+            return LocalizedStringResource("Button", comment: "Title of Button playground")
         case .color:
-            return LocalizedStringResource("Color")
+            return LocalizedStringResource("Color", comment: "Title of Color playground")
         case .colorScheme:
-            return LocalizedStringResource("ColorScheme")
+            return LocalizedStringResource("ColorScheme", comment: "Title of ColorScheme playground")
         case .compose:
-            return LocalizedStringResource("Compose")
+            return LocalizedStringResource("Compose", comment: "Title of Compose playground")
         case .confirmationDialog:
-            return LocalizedStringResource("ConfirmationDialog")
+            return LocalizedStringResource("ConfirmationDialog", comment: "Title of ConfirmationDialog playground")
         case .datePicker:
-            return LocalizedStringResource("DatePicker")
+            return LocalizedStringResource("DatePicker", comment: "Title of DatePicker playground")
         case .disclosureGroup:
-            return LocalizedStringResource("DisclosureGroup")
+            return LocalizedStringResource("DisclosureGroup", comment: "Title of DisclosureGroup playground")
         case .divider:
-            return LocalizedStringResource("Divider")
+            return LocalizedStringResource("Divider", comment: "Title of Divider playground")
         case .documentPicker:
-            return LocalizedStringResource("DocumentPicker")
+            return LocalizedStringResource("Document and Media Pickers", comment: "Title of Document and Media Pickers playground")
         case .environment:
-            return LocalizedStringResource("Environment")
+            return LocalizedStringResource("Environment", comment: "Title of Environment playground")
         case .focusState:
-            return LocalizedStringResource("FocusState")
+            return LocalizedStringResource("FocusState", comment: "Title of FocusState playground")
         case .form:
-            return LocalizedStringResource("Form")
+            return LocalizedStringResource("Form", comment: "Title of Form playground")
         case .frame:
-            return LocalizedStringResource("Frame")
+            return LocalizedStringResource("Frame", comment: "Title of Frame playground")
         case .geometryReader:
-            return LocalizedStringResource("GeometryReader")
+            return LocalizedStringResource("GeometryReader", comment: "Title of GeometryReader playground")
         case .gesture:
-            return LocalizedStringResource("Gestures")
+            return LocalizedStringResource("Gesture", comment: "Title of Gesture playground")
         case .gradient:
-            return LocalizedStringResource("Gradients")
+            return LocalizedStringResource("Gradient", comment: "Title of Gradient playground")
         case .graphics:
-            return LocalizedStringResource("Graphics")
+            return LocalizedStringResource("Graphics", comment: "Title of Graphics playground")
         case .grid:
-            return LocalizedStringResource("Grids")
+            return LocalizedStringResource("Grids", comment: "Title of Grids playground")
         case .hapticFeedback:
-            return LocalizedStringResource("Haptic Feedback")
+            return LocalizedStringResource("Haptick Feedback", comment: "Title of Haptick Feedback playground")
         case .icon:
-            return LocalizedStringResource("Icons")
+            return LocalizedStringResource("Icons", comment: "Title of Icons playground")
         case .image:
-            return LocalizedStringResource("Image")
+            return LocalizedStringResource("Image", comment: "Title of Image playground")
         case .keyboard:
-            return LocalizedStringResource("Keyboard")
+            return LocalizedStringResource("Keyboard", comment: "Title of Keyboard playground")
         case .keychain:
-            return LocalizedStringResource("Keychain")
-        case .link:
-            return LocalizedStringResource("Link")
+            return LocalizedStringResource("Keychain", comment: "Title of Keychain playground")
         case .label:
-            return LocalizedStringResource("Label")
+            return LocalizedStringResource("Label", comment: "Title of Label playground")
+        case .link:
+            return LocalizedStringResource("Link", comment: "Title of Link playground")
         case .list:
-            return LocalizedStringResource("List")
+            return LocalizedStringResource("List", comment: "Title of List playground")
         case .localization:
-            return LocalizedStringResource("Localization")
+            return LocalizedStringResource("Localization", comment: "Title of Localization playground")
         case .lottie:
-            return LocalizedStringResource("Lottie Animation")
+            return LocalizedStringResource("Lottie Animation", comment: "Title of Lottie playground")
         case .map:
-            return LocalizedStringResource("Map")
+            return LocalizedStringResource("Map", comment: "Title of Map playground")
         case .menu:
-            return LocalizedStringResource("Menu")
+            return LocalizedStringResource("Menu", comment: "Title of Menu playground")
         case .modifier:
-            return LocalizedStringResource("Modifiers")
+            return LocalizedStringResource("Modifiers", comment: "Title of Modifiers playground")
         case .navigationStack:
-            return LocalizedStringResource("NavigationStack")
+            return LocalizedStringResource("NavigationStack", comment: "Title of NavigationStack playground")
         case .observable:
-            return LocalizedStringResource("Observable")
+            return LocalizedStringResource("Observable", comment: "Title of Observable playground")
         case .offsetPosition:
-            return LocalizedStringResource("Offset/Position")
+            return LocalizedStringResource("Offset/Position", comment: "Title of Offset/Position playground")
         case .onSubmit:
-            return LocalizedStringResource("OnSubmit")
+            return LocalizedStringResource("OnSubmit", comment: "Title of OnSubmit playground")
         case .overlay:
-            return LocalizedStringResource("Overlay")
+            return LocalizedStringResource("Overlay", comment: "Title of Overlay playground")
         case .pasteboard:
-            return LocalizedStringResource("Pasteboard")
+            return LocalizedStringResource("Pasteboard", comment: "Title of Pasteboard playground")
         case .picker:
-            return LocalizedStringResource("Picker")
+            return LocalizedStringResource("Picker", comment: "Title of Picker playground")
         case .preference:
-            return LocalizedStringResource("Preferences")
+            return LocalizedStringResource("Preferences", comment: "Title of Preferences playground")
         case .progressView:
-            return LocalizedStringResource("ProgressView")
+            return LocalizedStringResource("ProgressView", comment: "Title of ProgressView playground")
         case .redacted:
-            return LocalizedStringResource("Redacted")
+            return LocalizedStringResource("Redacted", comment: "Title of Redacted playground")
         case .safeArea:
-            return LocalizedStringResource("SafeArea")
+            return LocalizedStringResource("SafeArea", comment: "Title of SafeArea playground")
         case .scenePhase:
-            return LocalizedStringResource("ScenePhase")
+            return LocalizedStringResource("ScenePhase", comment: "Title of ScenePhase playground")
         case .scrollView:
-            return LocalizedStringResource("ScrollView")
+            return LocalizedStringResource("ScrollView", comment: "Title of ScrollView playground")
         case .searchable:
-            return LocalizedStringResource("Searchable")
+            return LocalizedStringResource("Searchable", comment: "Title of Searchable playground")
         case .secureField:
-            return LocalizedStringResource("SecureField")
+            return LocalizedStringResource("SecureField", comment: "Title of SecureField playground")
         case .shadow:
-            return LocalizedStringResource("Shadow")
+            return LocalizedStringResource("Shadow", comment: "Title of Shadow playground")
         case .shape:
-            return LocalizedStringResource("Shape")
+            return LocalizedStringResource("Shape", comment: "Title of Shape playground")
         case .shareLink:
-            return LocalizedStringResource("ShareLink")
+            return LocalizedStringResource("ShareLink", comment: "Title of ShareLink playground")
         case .sheet:
-            return LocalizedStringResource("Sheet")
+            return LocalizedStringResource("Sheet", comment: "Title of Sheet playground")
         case .slider:
-            return LocalizedStringResource("Slider")
+            return LocalizedStringResource("Slider", comment: "Title of Slider playground")
         case .spacer:
-            return LocalizedStringResource("Spacer")
+            return LocalizedStringResource("Spacer", comment: "Title of Spacer playground")
         case .sql:
-            return LocalizedStringResource("SQL")
+            return LocalizedStringResource("SQL", comment: "Title of SQL playground")
         case .stack:
-            return LocalizedStringResource("Stacks")
+            return LocalizedStringResource("Stacks", comment: "Title of Stacks playground")
         case .state:
-            return LocalizedStringResource("State")
+            return LocalizedStringResource("State", comment: "Title of State playground")
         case .storage:
-            return LocalizedStringResource("Storage")
+            return LocalizedStringResource("Storage", comment: "Title of Storage playground")
         case .symbol:
-            return LocalizedStringResource("Symbol")
-        case .table:
-            return LocalizedStringResource("Table")
+            return LocalizedStringResource("Symbol", comment: "Title of Symbol playground")
+//        case .table:
+//            return LocalizedStringResource("Table")
         case .tabView:
-            return LocalizedStringResource("TabView")
+            return LocalizedStringResource("TabView", comment: "Title of TabView playground")
         case .text:
-            return LocalizedStringResource("Text")
+            return LocalizedStringResource("Text", comment: "Title of Text playground")
         case .textEditor:
-            return LocalizedStringResource("TextEditor")
+            return LocalizedStringResource("TextEditor", comment: "Title of Text playground")
         case .textField:
-            return LocalizedStringResource("TextField")
+            return LocalizedStringResource("TextField", comment: "Title of TextField playground")
         case .timer:
-            return LocalizedStringResource("Timer")
+            return LocalizedStringResource("Timer", comment: "Title of Timer playground")
         case .toggle:
-            return LocalizedStringResource("Toggle")
+            return LocalizedStringResource("Toggle", comment: "Title of Toggle playground")
         case .toolbar:
-            return LocalizedStringResource("Toolbar")
+            return LocalizedStringResource("Toolbar", comment: "Title of Toolbar playground")
         case .transition:
-            return LocalizedStringResource("Transition")
+            return LocalizedStringResource("Transition", comment: "Title of Transition playground")
         case .videoPlayer:
-            return LocalizedStringResource("Video Player")
+            return LocalizedStringResource("Video Player", comment: "Title of WebView playground")
         case .webView:
-            return LocalizedStringResource("WebView")
+            return LocalizedStringResource("WebView", comment: "Title of WebView playground")
         case .zIndex:
-            return LocalizedStringResource("ZIndex")
+            return LocalizedStringResource("ZIndex", comment: "Title of ZIndex playground")
         }
     }
 
@@ -245,8 +245,8 @@ enum PlaygroundType: CaseIterable, View {
             AlertPlayground()
         case .animation:
             AnimationPlayground()
-        case .audio:
-            AudioPlayground()
+//        case .audio:
+//            AudioPlayground()
         case .background:
             BackgroundPlayground()
         case .blur:
@@ -371,8 +371,8 @@ enum PlaygroundType: CaseIterable, View {
             StoragePlayground()
         case .symbol:
             SymbolPlayground()
-        case .table:
-            TablePlayground()
+//        case .table:
+//            TablePlayground()
         case .tabView:
             TabViewPlayground()
         case .text:
@@ -408,8 +408,10 @@ public struct PlaygroundNavigationView: View {
 
     public var body: some View {
         NavigationStack {
-            List(matchingPlaygroundTypes(), id: \.self) { playground in
-                NavigationLink(value: playground, label: { Text(playground.title) })
+            List {
+                ForEach(matchingPlaygroundTypes, id: \.self) { playground in
+                    NavigationLink(value: playground, label: { Text(playground.title) })
+                }
             }
             .navigationTitle(Text("Showcase"))
             .navigationDestination(for: PlaygroundType.self) {
@@ -419,11 +421,13 @@ public struct PlaygroundNavigationView: View {
         }
     }
 
-    private func matchingPlaygroundTypes() -> [PlaygroundType] {
+    private var matchingPlaygroundTypes: [PlaygroundType] {
         return PlaygroundType.allCases.filter {
-            let words = String(localized: $0.title).split(separator: " ")
+            let words = $0.title.key.split(separator: " ")
             let prefix = searchText.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
             return words.contains { $0.lowercased().starts(with: prefix) }
         }
     }
 }
+
+

--- a/Sources/Showcase/PlaygroundSourceLink.swift
+++ b/Sources/Showcase/PlaygroundSourceLink.swift
@@ -1,4 +1,5 @@
 // Copyright 2023–2025 Skip
+import Foundation
 import SwiftUI
 
 /// Displays a link to the source code for the given playground type.

--- a/Sources/Showcase/ProgressViewPlayground.swift
+++ b/Sources/Showcase/ProgressViewPlayground.swift
@@ -82,7 +82,3 @@ struct ProgressViewPlayground: View {
         }
     }
 }
-
-#Preview {
-    ProgressViewPlayground()
-}

--- a/Sources/Showcase/Resources/Localizable.xcstrings
+++ b/Sources/Showcase/Resources/Localizable.xcstrings
@@ -610,7 +610,7 @@
 
     },
     "Accessibility" : {
-
+      "comment" : "Title of Accessibility playground"
     },
     "Add item" : {
 
@@ -637,7 +637,7 @@
 
     },
     "Alert" : {
-
+      "comment" : "Title of Alert playground"
     },
     "alignment: .bottomTrailing" : {
 
@@ -652,7 +652,7 @@
 
     },
     "Animation" : {
-
+      "comment" : "Title of Animation playground"
     },
     "Appearance" : {
 
@@ -812,9 +812,6 @@
     "AsyncImage" : {
 
     },
-    "Audio" : {
-
-    },
     "B" : {
 
     },
@@ -825,7 +822,7 @@
 
     },
     "Background" : {
-
+      "comment" : "Title of Background playground"
     },
     "background()" : {
 
@@ -870,7 +867,7 @@
 
     },
     "Blur" : {
-
+      "comment" : "Title of Blur playground"
     },
     "Body" : {
 
@@ -885,7 +882,7 @@
 
     },
     "Border" : {
-
+      "comment" : "Title of Border playground"
     },
     "Bottom" : {
 
@@ -909,7 +906,7 @@
 
     },
     "Button" : {
-
+      "comment" : "Title of Button playground"
     },
     "Button .automatic" : {
 
@@ -963,13 +960,13 @@
 
     },
     "Color" : {
-
+      "comment" : "Title of Color playground"
     },
     "Color + Offset" : {
 
     },
     "ColorScheme" : {
-
+      "comment" : "Title of ColorScheme playground"
     },
     "Combined: opacity+slide" : {
 
@@ -984,10 +981,10 @@
 
     },
     "Compose" : {
-
+      "comment" : "Title of Compose playground"
     },
     "ConfirmationDialog" : {
-
+      "comment" : "Title of ConfirmationDialog playground"
     },
     "Container" : {
 
@@ -1053,7 +1050,7 @@
 
     },
     "DatePicker" : {
-
+      "comment" : "Title of DatePicker playground"
     },
     "DatePicker .disabled" : {
 
@@ -1079,8 +1076,18 @@
     "Disabled Tab" : {
 
     },
+    "Disabled tap: (%lld, %lld)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disabled tap: (%1$lld, %2$lld)"
+          }
+        }
+      }
+    },
     "DisclosureGroup" : {
-
+      "comment" : "Title of DisclosureGroup playground"
     },
     "DisclosureGroup .disabled" : {
 
@@ -1095,10 +1102,10 @@
 
     },
     "Divider" : {
-
+      "comment" : "Title of Divider playground"
     },
-    "DocumentPicker" : {
-
+    "Document and Media Pickers" : {
+      "comment" : "Title of Document and Media Pickers playground"
     },
     "Done" : {
       "comment" : "Done button text",
@@ -1190,7 +1197,7 @@
 
     },
     "Environment" : {
-
+      "comment" : "Title of Environment playground"
     },
     "EnvironmentObject" : {
 
@@ -1256,7 +1263,7 @@
 
     },
     "FocusState" : {
-
+      "comment" : "Title of FocusState playground"
     },
     "Font.body" : {
 
@@ -1365,13 +1372,13 @@
 
     },
     "Form" : {
-
+      "comment" : "Title of Form playground"
     },
     "Forward" : {
 
     },
     "Frame" : {
-
+      "comment" : "Title of Frame playground"
     },
     "Full screen .topLeading container" : {
 
@@ -1383,9 +1390,12 @@
 
     },
     "GeometryReader" : {
-
+      "comment" : "Title of GeometryReader playground"
     },
-    "Gestures" : {
+    "Gesture" : {
+      "comment" : "Title of Gesture playground"
+    },
+    "GestureState Drag" : {
 
     },
     "Global Drag" : {
@@ -1394,11 +1404,11 @@
     "Global frame: %@" : {
 
     },
-    "Gradients" : {
-
+    "Gradient" : {
+      "comment" : "Title of Gradient playground"
     },
     "Graphics" : {
-
+      "comment" : "Title of Graphics playground"
     },
     "Gray" : {
 
@@ -1407,16 +1417,16 @@
 
     },
     "Grids" : {
-
-    },
-    "Haptic Feedback" : {
-
+      "comment" : "Title of Grids playground"
     },
     "Haptic Feedback Unavailable in this OS version" : {
 
     },
     "Haptic Feedback: %@" : {
 
+    },
+    "Haptick Feedback" : {
+      "comment" : "Title of Haptick Feedback playground"
     },
     "Has strings:" : {
 
@@ -1505,10 +1515,10 @@
 
     },
     "Icons" : {
-
+      "comment" : "Title of Icons playground"
     },
     "Image" : {
-
+      "comment" : "Title of Image playground"
     },
     "Image from Data" : {
 
@@ -1592,16 +1602,16 @@
 
     },
     "Keyboard" : {
-
+      "comment" : "Title of Keyboard playground"
     },
     "Keychain" : {
-
+      "comment" : "Title of Keychain playground"
     },
     "Keychain value" : {
 
     },
     "Label" : {
-
+      "comment" : "Title of Label playground"
     },
     "Label .font(.title)" : {
 
@@ -1697,10 +1707,10 @@
 
     },
     "Link" : {
-
+      "comment" : "Title of Link playground"
     },
     "List" : {
-
+      "comment" : "Title of List playground"
     },
     "List.%@" : {
 
@@ -1709,7 +1719,7 @@
 
     },
     "Localization" : {
-
+      "comment" : "Title of Localization playground"
     },
     "Long press: %lld" : {
 
@@ -1727,13 +1737,13 @@
 
     },
     "Lottie Animation" : {
-
+      "comment" : "Title of Lottie playground"
     },
     "Magnify" : {
 
     },
     "Map" : {
-
+      "comment" : "Title of Map playground"
     },
     "Map requires iOS 17" : {
 
@@ -1776,7 +1786,7 @@
 
     },
     "Menu" : {
-
+      "comment" : "Title of Menu playground"
     },
     "Mint" : {
 
@@ -1791,7 +1801,7 @@
 
     },
     "Modifiers" : {
-
+      "comment" : "Title of Modifiers playground"
     },
     "More (page 2)" : {
 
@@ -1830,7 +1840,7 @@
 
     },
     "NavigationStack" : {
-
+      "comment" : "Title of NavigationStack playground"
     },
     "Negative padding" : {
 
@@ -1884,6 +1894,9 @@
     "Not supported on macOS" : {
 
     },
+    "Not supported on macOS or Skip Fuse" : {
+
+    },
     "Note: colors should not affect Divider appearance" : {
 
     },
@@ -1893,11 +1906,8 @@
     "Note: tint should not affect Label appearance" : {
 
     },
-    "Notifications" : {
-
-    },
     "Observable" : {
-
+      "comment" : "Title of Observable playground"
     },
     "Observable tap count: %lld" : {
 
@@ -1909,7 +1919,7 @@
 
     },
     "Offset/Position" : {
-
+      "comment" : "Title of Offset/Position playground"
     },
     "On" : {
 
@@ -1918,7 +1928,7 @@
 
     },
     "OnSubmit" : {
-
+      "comment" : "Title of OnSubmit playground"
     },
     "onTapGesture: (%lld, %lld)" : {
       "localizations" : {
@@ -1961,7 +1971,7 @@
 
     },
     "Overlay" : {
-
+      "comment" : "Title of Overlay playground"
     },
     "Overridden to title font" : {
 
@@ -1988,7 +1998,7 @@
 
     },
     "Pasteboard" : {
-
+      "comment" : "Title of Pasteboard playground"
     },
     "Pasteboard count:" : {
 
@@ -2046,7 +2056,7 @@
 
     },
     "Picker" : {
-
+      "comment" : "Title of Picker playground"
     },
     "Picker .disabled" : {
 
@@ -2078,23 +2088,30 @@
     "Plain Style" : {
 
     },
-    "Play" : {
-
-    },
     "Play Recording" : {
 
     },
     "Pop" : {
 
     },
-    "Powered by [Skip](https://skip.tools)" : {
+    "Pop %lld / %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pop %1$lld / %2$lld"
+          }
+        }
+      }
+    },
+    "Powered by [%@](https://skip.tools)" : {
 
     },
     "Preference value: %lld" : {
 
     },
     "Preferences" : {
-
+      "comment" : "Title of Preferences playground"
     },
     "Present" : {
 
@@ -2148,7 +2165,7 @@
 
     },
     "ProgressView" : {
-
+      "comment" : "Title of ProgressView playground"
     },
     "Prompt" : {
 
@@ -2196,7 +2213,7 @@
 
     },
     "Redacted" : {
-
+      "comment" : "Title of Redacted playground"
     },
     "Refreshable" : {
 
@@ -2262,7 +2279,7 @@
 
     },
     "SafeArea" : {
-
+      "comment" : "Title of SafeArea playground"
     },
     "Save" : {
 
@@ -2280,7 +2297,7 @@
 
     },
     "ScenePhase" : {
-
+      "comment" : "Title of ScenePhase playground"
     },
     "ScenePhase history" : {
 
@@ -2304,7 +2321,7 @@
 
     },
     "ScrollView" : {
-
+      "comment" : "Title of ScrollView playground"
     },
     "ScrollView.%@" : {
 
@@ -2313,7 +2330,7 @@
 
     },
     "Searchable" : {
-
+      "comment" : "Title of Searchable playground"
     },
     "Second" : {
 
@@ -2352,7 +2369,7 @@
 
     },
     "SecureField" : {
-
+      "comment" : "Title of SecureField playground"
     },
     "Select Media" : {
 
@@ -2455,10 +2472,10 @@
       }
     },
     "Shadow" : {
-
+      "comment" : "Title of Shadow playground"
     },
     "Shape" : {
-
+      "comment" : "Title of Shape playground"
     },
     "Shape with background" : {
 
@@ -2467,10 +2484,10 @@
 
     },
     "ShareLink" : {
-
+      "comment" : "Title of ShareLink playground"
     },
     "Sheet" : {
-
+      "comment" : "Title of Sheet playground"
     },
     "Short text" : {
 
@@ -2662,7 +2679,7 @@
 
     },
     "Slider" : {
-
+      "comment" : "Title of Slider playground"
     },
     "Slow spring" : {
 
@@ -2674,16 +2691,16 @@
 
     },
     "Spacer" : {
-
+      "comment" : "Title of Spacer playground"
     },
     "Spacer:" : {
 
     },
     "SQL" : {
-
+      "comment" : "Title of SQL playground"
     },
     "Stacks" : {
-
+      "comment" : "Title of Stacks playground"
     },
     "Standalone row 1" : {
 
@@ -2704,22 +2721,16 @@
 
     },
     "State" : {
-
+      "comment" : "Title of State playground"
     },
     "State tap count: %lld" : {
-
-    },
-    "State: %@" : {
-
-    },
-    "Stop" : {
 
     },
     "Stop Recording" : {
 
     },
     "Storage" : {
-
+      "comment" : "Title of Storage playground"
     },
     "Storage Binding" : {
 
@@ -2785,7 +2796,7 @@
 
     },
     "Symbol" : {
-
+      "comment" : "Title of Symbol playground"
     },
     "Symbol Image Sizes" : {
 
@@ -2805,11 +2816,11 @@
     "systemName" : {
 
     },
-    "Table" : {
+    "Table not yet supported in Skip Fuse" : {
 
     },
     "TabView" : {
-
+      "comment" : "Title of TabView playground"
     },
     "Take Photo" : {
 
@@ -2888,7 +2899,7 @@
 
     },
     "Text" : {
-
+      "comment" : "Title of Text playground"
     },
     "Text / URL" : {
 
@@ -2930,10 +2941,10 @@
 
     },
     "TextEditor" : {
-
+      "comment" : "Title of Text playground"
     },
     "TextField" : {
-
+      "comment" : "Title of TextField playground"
     },
     "Thin footnote container" : {
 
@@ -2981,7 +2992,7 @@
 
     },
     "Timer" : {
-
+      "comment" : "Title of Timer playground"
     },
     "Title" : {
 
@@ -2996,7 +3007,7 @@
 
     },
     "Toggle" : {
-
+      "comment" : "Title of Toggle playground"
     },
     "Toggle Group" : {
 
@@ -3005,7 +3016,7 @@
 
     },
     "Toolbar" : {
-
+      "comment" : "Title of Toolbar playground"
     },
     "Top" : {
 
@@ -3017,7 +3028,7 @@
 
     },
     "Transition" : {
-
+      "comment" : "Title of Transition playground"
     },
     "Two Buttons" : {
 
@@ -3078,7 +3089,7 @@
 
     },
     "Video Player" : {
-
+      "comment" : "Title of WebView playground"
     },
     "View 0" : {
 
@@ -3189,7 +3200,7 @@
 
     },
     "WebView" : {
-
+      "comment" : "Title of WebView playground"
     },
     "Welcome" : {
       "comment" : "welcome string",
@@ -3328,6 +3339,9 @@
         }
       }
     },
+    "Welcome %@" : {
+
+    },
     "White" : {
 
     },
@@ -3377,7 +3391,7 @@
 
     },
     "ZIndex" : {
-
+      "comment" : "Title of ZIndex playground"
     },
     "ZStack.animation" : {
 

--- a/Sources/Showcase/SQLPlayground.swift
+++ b/Sources/Showcase/SQLPlayground.swift
@@ -1,6 +1,7 @@
 // Copyright 2023–2025 Skip
 import SwiftUI
 import SkipSQL
+import SkipSQLPlus
 
 struct SQLPlayground: View {
     /// The shared global SQL context for the whole app
@@ -65,7 +66,7 @@ struct SQLPlayground: View {
     private static func openDatabase() throws -> SQLContext {
         let dir = URL.applicationSupportDirectory
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let ctx = try SQLContext(path: dir.appendingPathComponent("db.sqlite").path, flags: [.create, .readWrite])
+        let ctx = try SQLContext(path: dir.appendingPathComponent("db.sqlite").path, flags: [.create, .readWrite], configuration: .plus)
 
         ctx.trace { sql in
             logger.info("SQLPlayground: \(sql)")

--- a/Sources/Showcase/ScenePhasePlayground.swift
+++ b/Sources/Showcase/ScenePhasePlayground.swift
@@ -13,10 +13,9 @@ struct ScenePhasePlayground: View {
                 }
             }
         }
-        .onChange(of: scenePhase) { phase in
-            logger.log("onChange(of: schenePhase): \(String(describing: phase))")
-            history.append(phase)
-
+        .onChange(of: scenePhase) { oldValue, newValue in
+            logger.log("onChange(of: schenePhase): \(String(describing: newValue))")
+            history.append(newValue)
         }
         .toolbar {
             PlaygroundSourceLink(file: "ScenePhasePlayground.swift")

--- a/Sources/Showcase/ScrollViewPlayground.swift
+++ b/Sources/Showcase/ScrollViewPlayground.swift
@@ -78,7 +78,7 @@ struct ScrollViewPlayground: View {
     }
 }
 
-private struct VerticalScrollViewPlayground: View {
+struct VerticalScrollViewPlayground: View {
     var body: some View {
         ScrollView {
             VStack {
@@ -94,7 +94,7 @@ private struct VerticalScrollViewPlayground: View {
     }
 }
 
-private struct HorizontalScrollViewPlayground: View {
+struct HorizontalScrollViewPlayground: View {
     var body: some View {
         ScrollView(.horizontal) {
             HStack {
@@ -107,7 +107,7 @@ private struct HorizontalScrollViewPlayground: View {
     }
 }
 
-private struct ViewAlignedScrollViewPlayground: View {
+struct ViewAlignedScrollViewPlayground: View {
     var body: some View {
         if #available(iOS 17, *) {
             ScrollView(.horizontal) {
@@ -129,7 +129,7 @@ private struct ViewAlignedScrollViewPlayground: View {
     }
 }
 
-private struct ScrollViewReaderLazyVStackPlayground: View {
+struct ScrollViewReaderLazyVStackPlayground: View {
     var body: some View {
         ScrollViewReader { proxy in
             VStack(spacing: 16) {
@@ -149,7 +149,7 @@ private struct ScrollViewReaderLazyVStackPlayground: View {
     }
 }
 
-private struct ScrollViewReaderLazyHStackPlayground: View {
+struct ScrollViewReaderLazyHStackPlayground: View {
     var body: some View {
         ScrollViewReader { proxy in
             VStack(spacing: 16) {
@@ -169,7 +169,7 @@ private struct ScrollViewReaderLazyHStackPlayground: View {
     }
 }
 
-private struct ScrollViewReaderListPlayground: View {
+struct ScrollViewReaderListPlayground: View {
     var body: some View {
         ScrollViewReader { proxy in
             VStack(spacing: 16) {
@@ -198,7 +198,7 @@ private struct ScrollViewReaderListPlayground: View {
     }
 }
 
-private struct ScrollViewReaderStaticListPlayground: View {
+struct ScrollViewReaderStaticListPlayground: View {
     var body: some View {
         ScrollViewReader { proxy in
             VStack(spacing: 16) {
@@ -278,7 +278,7 @@ private struct ScrollViewReaderStaticListPlayground: View {
     }
 }
 
-private struct ScrollViewReaderLazyVGridPlayground: View {
+struct ScrollViewReaderLazyVGridPlayground: View {
     var body: some View {
         ScrollViewReader { proxy in
             VStack(spacing: 16) {
@@ -301,7 +301,7 @@ private struct ScrollViewReaderLazyVGridPlayground: View {
     }
 }
 
-private struct ScrollViewReaderLazyHGridPlayground: View {
+struct ScrollViewReaderLazyHGridPlayground: View {
     var body: some View {
         ScrollViewReader { proxy in
             VStack(spacing: 16) {
@@ -324,7 +324,7 @@ private struct ScrollViewReaderLazyHGridPlayground: View {
     }
 }
 
-private struct ScrollViewReaderJumpButtons: View {
+struct ScrollViewReaderJumpButtons: View {
     let proxy: ScrollViewProxy
 
     var body: some View {

--- a/Sources/Showcase/SearchablePlayground.swift
+++ b/Sources/Showcase/SearchablePlayground.swift
@@ -1,5 +1,4 @@
 // Copyright 2023–2025 Skip
-import Foundation
 import SwiftUI
 
 enum SearchablePlaygroundType: String, CaseIterable {
@@ -189,7 +188,7 @@ struct IsSearchingSearchablePlayground: View {
             .searchable(text: $searchText)
     }
 
-    private struct IsSearchingView: View {
+    struct IsSearchingView: View {
         @Environment(\.isSearching) var isSearching
 
         var body: some View {

--- a/Sources/Showcase/SettingsView.swift
+++ b/Sources/Showcase/SettingsView.swift
@@ -1,4 +1,5 @@
 // Copyright 2023–2025 Skip
+import Foundation
 import SwiftUI
 
 struct SettingsView: View {
@@ -37,21 +38,38 @@ struct SettingsView: View {
                 }
                 HStack {
                     #if SKIP
+                    let powered = "Skip Lite"
                     ComposeView { ctx in // Mix in Compose code!
                         androidx.compose.material3.Text("💚", modifier: ctx.modifier)
                     }
-                    #else
+                    #elseif os(Android)
+                    let powered = "Skip Fuse"
+                    ComposeView {
+                        HeartComposer()
+                    }
+                    #elseif os(iOS)
+                    let powered = "SwiftUI and Skip"
                     Text(verbatim: "💙")
                     #endif
+                    Text("Powered by [\(powered)](https://skip.tools)")
+                }
+                HStack {
                     if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
                        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
                         Text("Version \(version) (\(buildNumber))")
                             .foregroundStyle(.gray)
                     }
-                    Text("Powered by [Skip](https://skip.tools)")
                 }
             }
             .navigationTitle("Settings")
         }
     }
 }
+
+#if SKIP
+struct HeartComposer : ContentComposer {
+    @Composable func Compose(context: ComposeContext) {
+        androidx.compose.material3.Text("💚", modifier: context.modifier)
+    }
+}
+#endif

--- a/Sources/Showcase/ShowcaseApp.swift
+++ b/Sources/Showcase/ShowcaseApp.swift
@@ -1,45 +1,59 @@
-// Copyright 2023–2025 Skip
 import Foundation
-import OSLog
 import SwiftUI
+#if canImport(OSLog)
+import OSLog
+#elseif os(Android) && !SKIP
+import AndroidLogging
+#endif
 
-let logger = Logger(subsystem: "showcase.app", category: "ShowcaseApp")
-
-/// URL string of the source this app.
-let showcaseSourceURLString = "https://source.skip.tools/skipapp-showcase/tree/main/"
-let playgroundPath = "Sources/Showcase/"
-
-/// The Android SDK number we are running against, or `nil` if not running on Android
-let androidSDK = ProcessInfo.processInfo.environment["android.os.Build.VERSION.SDK_INT"].flatMap({ Int($0) })
+let logger: Logger = Logger(subsystem: "skip.showcase", category: "Showcase")
 
 /// The shared top-level view for the app, loaded from the platform-specific App delegates below.
 ///
 /// The default implementation merely loads the `ContentView` for the app and logs a message.
-public struct RootView : View {
-    public init() {
+/* SKIP @bridge */public struct ShowcaseRootView : View {
+    /* SKIP @bridge */public init() {
     }
 
     public var body: some View {
         ContentView()
-            .onAppear {
-                logger.log("Welcome to Skip on \(androidSDK != nil ? "Android" : "Darwin")!")
-                logger.warning("Skip app logs are viewable in the Xcode console for iOS; Android logs can be viewed in Studio or using adb logcat")
+            .task {
+                logger.info("Skip app logs are viewable in the Xcode console for iOS; Android logs can be viewed in Studio or using adb logcat")
             }
     }
 }
 
-#if !SKIP
-public protocol ShowcaseApp : App {
-}
+/// Global application delegate functions.
+///
+/// These functions can update a shared observable object to communicate app state changes to interested views.
+/// The sender for each of these functions will be either a `UIApplication` (iOS) or `AppCompatActivity` (Android)
+/* SKIP @bridge */public final class ShowcaseAppDelegate : Sendable {
+    /* SKIP @bridge */public static let shared = ShowcaseAppDelegate()
 
-/// The entry point to the Showcase app.
-/// The concrete implementation is in the ShowcaseApp module.
-public extension ShowcaseApp {
-    var body: some Scene {
-        WindowGroup {
-            RootView()
-        }
+    private init() {
+    }
+
+    /* SKIP @bridge */public func onStart() {
+        logger.debug("onStart")
+    }
+
+    /* SKIP @bridge */public func onResume() {
+        logger.debug("onResume")
+    }
+
+    /* SKIP @bridge */ public func onPause() {
+        logger.debug("onPause")
+    }
+
+    /* SKIP @bridge */public func onStop() {
+        logger.debug("onStop")
+    }
+
+    /* SKIP @bridge */public func onDestroy() {
+        logger.debug("onDestroy")
+    }
+
+    /* SKIP @bridge */public func onLowMemory() {
+        logger.debug("onLowMemory")
     }
 }
-
-#endif

--- a/Sources/Showcase/Skip/skip.yml
+++ b/Sources/Showcase/Skip/skip.yml
@@ -2,6 +2,12 @@
 # settings.gradle.kts and build.gradle.kts, which the Gradle build system
 # uses to configure the build. Dependencies, metadata, versions, and configuration
 # settings are all specified here. See https://skip.tools/docs
+skip:
+  # automatic will be 'native' when depending on SkipFuse, otherwise 'transpiled'
+  #mode: 'automatic'
+  #mode: 'native'
+  mode: 'transpiled'
+
 build:
   contents:
     - block: 'dependencies'

--- a/Sources/Showcase/StackPlayground.swift
+++ b/Sources/Showcase/StackPlayground.swift
@@ -205,7 +205,7 @@ struct StackPlayground: View {
     }
 }
 
-private struct LazyVStackScrollView: View {
+struct LazyVStackScrollView: View {
     let count: Int
 
     var body: some View {
@@ -217,7 +217,7 @@ private struct LazyVStackScrollView: View {
     }
 }
 
-private struct LazyVStackView: View {
+struct LazyVStackView: View {
     let count: Int
 
     var body: some View {
@@ -233,7 +233,7 @@ private struct LazyVStackView: View {
     }
 }
 
-private struct ScrollViewStacksView: View {
+struct ScrollViewStacksView: View {
     var body: some View {
         ScrollView(.vertical) {
           ScrollView(.horizontal) {

--- a/Sources/Showcase/StatePlayground.swift
+++ b/Sources/Showcase/StatePlayground.swift
@@ -6,12 +6,12 @@ struct StatePlayground: View {
     @State var hasStateTapped: Bool? // Test optional vars
     @State var tapCountObservable: TapCountObservable
     @State var tapCountStruct: TapCountStruct
-    @StateObject var tapCountRepository = TapCountRepository() // Test ForEach observable
+    @State var tapCountRepository = TapCountRepository() // Test ForEach observable
 
     init() {
         // Test that we can initialze state property wrappers
         _tapCountObservable = State(initialValue: TapCountObservable())
-        _tapCountStruct = State(initialValue: TapCountStruct())
+        _tapCountStruct = State(wrappedValue: TapCountStruct())
     }
 
     var body: some View {
@@ -68,14 +68,14 @@ struct StatePlayground: View {
                 }
             }
         }
-        .onChange(of: tapCount) {
-            logger.log("onChange(of: tapCount): \($0)")
+        .onChange(of: tapCount) { oldValue, newValue in
+            logger.log("onChange(of: tapCount): \(newValue)")
         }
-        .onChange(of: tapCountObservable.tapCount) {
-            logger.log("onChange(of: tapCountObservable.tapCount): \($0)")
+        .onChange(of: tapCountObservable.tapCount) { oldValue, newValue in
+            logger.log("onChange(of: tapCountObservable.tapCount): \(newValue)")
         }
-        .onChange(of: tapCountStruct.tapCount) {
-            logger.log("onChange(of: tapCountStruct.tapCount): \($0)")
+        .onChange(of: tapCountStruct.tapCount) { oldValue, newValue in
+            logger.log("onChange(of: tapCountStruct.tapCount): \(newValue)")
         }
         .toolbar {
             PlaygroundSourceLink(file: "StatePlayground.swift")

--- a/Sources/Showcase/StatePlaygroundModel.swift
+++ b/Sources/Showcase/StatePlaygroundModel.swift
@@ -1,6 +1,10 @@
 // Copyright 2023–2025 Skip
-import Combine
 import Observation
+#if canImport(SkipFuse) && !SKIP
+import SkipFuse
+#endif
+
+// Test that observables in a different file work
 
 @Observable
 class TapCountObservable {
@@ -12,8 +16,9 @@ struct TapCountStruct : Identifiable {
     var tapCount = 0
 }
 
-class TapCountRepository: ObservableObject {
-    @Published var items: [TapCountStruct] = []
+@Observable
+class TapCountRepository {
+    var items: [TapCountStruct] = []
 
     func add() {
         items.append(TapCountStruct(id: items.count))

--- a/Sources/Showcase/TablePlayground.swift
+++ b/Sources/Showcase/TablePlayground.swift
@@ -1,6 +1,7 @@
 // Copyright 2023–2025 Skip
 import SwiftUI
 
+
 enum TablePlaygroundType: String, CaseIterable {
     case defaultColumns
     case fixedWidthColumns
@@ -24,6 +25,13 @@ enum TablePlaygroundType: String, CaseIterable {
     }
 }
 
+#if !os(iOS) || !SKIP // Skip Lite only
+struct TablePlayground: View {
+    var body: some View {
+        Text("Table not yet supported in Skip Fuse")
+    }
+}
+#else
 struct TablePlayground: View {
     var body: some View {
         List(TablePlaygroundType.allCases, id: \.self) { type in
@@ -54,7 +62,7 @@ struct TablePlayground: View {
     }
 }
 
-private struct TableData: Identifiable {
+struct TableData: Identifiable {
     let id = UUID()
     let name: String
     let value: Int
@@ -64,7 +72,7 @@ private struct TableData: Identifiable {
     }
 }
 
-private struct DefaultColumnsTablePlayground: View {
+struct DefaultColumnsTablePlayground: View {
     @State var data = TableData.initialData
 
     var body: some View {
@@ -81,7 +89,7 @@ private struct DefaultColumnsTablePlayground: View {
     }
 }
 
-private struct FixedWidthColumnsTablePlayground: View {
+struct FixedWidthColumnsTablePlayground: View {
     @State var data = TableData.initialData
 
     var body: some View {
@@ -100,7 +108,7 @@ private struct FixedWidthColumnsTablePlayground: View {
     }
 }
 
-private struct RangeWidthColumnsTablePlayground: View {
+struct RangeWidthColumnsTablePlayground: View {
     @State var data = TableData.initialData
 
     var body: some View {
@@ -119,7 +127,7 @@ private struct RangeWidthColumnsTablePlayground: View {
     }
 }
 
-private struct SelectionTablePlayground: View {
+struct SelectionTablePlayground: View {
     @State var data = TableData.initialData
     @State var selection: UUID?
 
@@ -137,7 +145,7 @@ private struct SelectionTablePlayground: View {
     }
 }
 
-private struct SelectionSetTablePlayground: View {
+struct SelectionSetTablePlayground: View {
     @State var data = TableData.initialData
     @State var selection: Set<UUID> = []
 
@@ -154,3 +162,4 @@ private struct SelectionSetTablePlayground: View {
         }
     }
 }
+#endif

--- a/Sources/Showcase/TextFieldPlayground.swift
+++ b/Sources/Showcase/TextFieldPlayground.swift
@@ -1,7 +1,6 @@
 // Copyright 2023–2025 Skip
 import SwiftUI
 
-
 struct TextFieldPlayground: View {
     @State var text = ""
     @State var phone = ""
@@ -54,7 +53,7 @@ struct TextFieldPlayground: View {
                     #if !os(macOS) || os(Android)
                     .keyboardType(UIKeyboardType.phonePad)
                     #endif
-                    .onChange(of: phone) { newValue in
+                    .onChange(of: phone) { oldValue, newValue in
                         phone = formatPhone(newValue)
                     }
                 TextField("Email", text: $text)

--- a/Sources/Showcase/TextPlayground.swift
+++ b/Sources/Showcase/TextPlayground.swift
@@ -64,9 +64,11 @@ struct TextPlayground: View {
 
                 Divider()
 
+                #if SKIP // Skip Lite only
                 Text(try! AttributedString(markdown: "Attributed *Italic text* with \("substitution1") and \("substitution2")"))
                 Text(try! AttributedString(markdown: "Attributed **Bold text** with .italic()"))
                     .italic()
+                #endif
 
                 Divider()
 

--- a/Sources/Showcase/TimerPlayground.swift
+++ b/Sources/Showcase/TimerPlayground.swift
@@ -20,9 +20,9 @@ struct TimerPlayground: View {
     }
 }
 
-private struct TimerPlaygroundTimerView: View {
+struct TimerPlaygroundTimerView: View, @unchecked Sendable {
     let message: String
-    let timer = Timer.publish(every: 1.0, on: .main, in: .default).autoconnect()
+    @State var timer: Timer?
     @State var timerDate: Date?
     @State var ticks = 0
 
@@ -33,9 +33,15 @@ private struct TimerPlaygroundTimerView: View {
             Text("Ticks: \(ticks)")
         }
         .font(.largeTitle)
-        .onReceive(timer) { date in
-            timerDate = date
-            ticks += 1
+        .task {
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(nanoseconds: 1_000_000_000)
+                    timerDate = Date()
+                    ticks += 1
+                } catch {
+                }
+            }
         }
     }
 }

--- a/Sources/Showcase/ToolbarPlayground.swift
+++ b/Sources/Showcase/ToolbarPlayground.swift
@@ -1,7 +1,7 @@
 // Copyright 2023–2025 Skip
 import SwiftUI
 
-enum ToolbarPlaygroundType: String, CaseIterable {
+enum ToolbarPlaygroundType: View, CaseIterable {
     case hideNavigationBar
     case hideBars
     case hideBarBackgrounds
@@ -16,6 +16,7 @@ enum ToolbarPlaygroundType: String, CaseIterable {
     case tint
     case custom
     case label
+    case stateful
     case toolbarItem
     case toolbarItemGroup
     case topLeadingItem
@@ -61,6 +62,8 @@ enum ToolbarPlaygroundType: String, CaseIterable {
             return "Custom"
         case .label:
             return "Label"
+        case .stateful:
+            return "Stateful"
         case .toolbarItem:
             return "ToolbarItem"
         case .toolbarItemGroup:
@@ -91,180 +94,169 @@ enum ToolbarPlaygroundType: String, CaseIterable {
             return ".toolbarTitleMenu"
         }
     }
+
+    var body: some View {
+        switch self {
+        case .hideNavigationBar:
+            #if os(macOS)
+            Text("Not supported on macOS")
+            #else
+            HideToolbarsPlayground()
+                .toolbar(.hidden, for: .navigationBar)
+                .ignoresSafeArea(edges: .top)
+            #endif
+        case .hideBars:
+            #if os(macOS)
+            Text("Not supported on macOS")
+            #else
+            HideToolbarsPlayground()
+                .toolbar(.hidden)
+                .ignoresSafeArea()
+            #endif
+        case .hideBarBackgrounds:
+            #if os(macOS)
+            Text("Not supported on macOS")
+            #else
+            HideToolbarsPlayground()
+                .toolbarBackground(.hidden, for: .navigationBar, .tabBar)
+            #endif
+        case .customBarColor:
+            #if os(macOS)
+            Text("Not supported on macOS")
+            #else
+            HideToolbarsPlayground()
+                .toolbarBackground(.blue, for: .navigationBar, .tabBar)
+            #endif
+        case .visibleCustomBarColor:
+            #if os(macOS)
+            Text("Not supported on macOS")
+            #else
+            HideToolbarsPlayground()
+                .toolbarBackground(.blue, for: .navigationBar, .tabBar)
+                .toolbarBackground(.visible, for: .navigationBar, .tabBar)
+            #endif
+        case .customBarBrush:
+            #if os(macOS)
+            Text("Not supported on macOS")
+            #else
+            HideToolbarsPlayground()
+                .toolbarBackground(.blue.gradient, for: .navigationBar, .tabBar)
+            #endif
+        case .customInlineBarBrush:
+            #if os(macOS)
+            Text("Not supported on macOS")
+            #else
+            HideToolbarsPlayground()
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbarBackground(.blue.gradient, for: .navigationBar, .tabBar)
+            #endif
+        case .customBarColorScheme:
+            #if os(macOS)
+            Text("Not supported on macOS")
+            #else
+            HideToolbarsPlayground()
+                .toolbarColorScheme(.dark, for: .navigationBar, .tabBar)
+            #endif
+        case .customBarColorSchemeBrush:
+            #if os(macOS)
+            Text("Not supported on macOS")
+            #else
+            HideToolbarsPlayground()
+                .toolbarColorScheme(.dark, for: .navigationBar, .tabBar)
+                .toolbarBackground(.blue.gradient, for: .navigationBar, .tabBar)
+            #endif
+        case .default:
+            DefaultToolbarItemPlayground()
+        case .updating:
+            UpdatingToolbarItemPlayground()
+        case .tint:
+            TintToolbarItemGroupPlayground()
+        case .custom:
+            CustomToolbarItemPlayground()
+        case .label:
+            LabelToolbarItemPlayground()
+        case .stateful:
+            StatefulToolbarItemPlayground()
+        case .toolbarItem:
+            ToolbarItemPlayground(placement: ToolbarItemPlacement.automatic, placement2: ToolbarItemPlacement.automatic)
+        case .toolbarItemGroup:
+            ToolbarItemGroupPlayground(placement: ToolbarItemPlacement.automatic)
+        case .topLeadingItem:
+            #if os(macOS) // ToolbarItemPlacement.topBarLeading unavailable on macOS
+            Text("Not supported on macOS")
+            #else
+            ToolbarItemPlayground(placement: ToolbarItemPlacement.topBarLeading)
+            #endif
+        case .topLeadingItemGroup:
+            #if os(macOS) // ToolbarItemPlacement.topBarLeading unavailable on macOS
+            Text("Not supported on macOS")
+            #else
+            ToolbarItemGroupPlayground(placement: ToolbarItemPlacement.topBarLeading)
+            #endif
+        case .topLeadingBackButtonHidden:
+            #if os(macOS) // ToolbarItemPlacement.topBarLeading unavailable on macOS
+            Text("Not supported on macOS")
+            #else
+            ToolbarBackButtonHiddenPlayground()
+            #endif
+        case .topLeadingTrailingItems:
+            #if os(macOS) // ToolbarItemPlacement.topBarLeading unavailable on macOS
+            Text("Not supported on macOS")
+            #else
+            ToolbarItemPlayground(placement: ToolbarItemPlacement.topBarLeading, placement2: ToolbarItemPlacement.topBarTrailing)
+            #endif
+        case .principalItem:
+            ToolbarItemPrincipalPlayground()
+        case .bottom:
+            #if os(macOS) // ToolbarItemPlacement.bottomBar unavailable on macOS
+            Text("Not supported on macOS")
+            #else
+            ToolbarItemPlayground(placement: ToolbarItemPlacement.bottomBar, placement2: ToolbarItemPlacement.bottomBar)
+            #endif
+        case .bottomPlain:
+            #if os(macOS) // ToolbarItemPlacement.bottomBar unavailable on macOS
+            Text("Not supported on macOS")
+            #else
+            ToolbarItemPlainStylePlayground(placement: ToolbarItemPlacement.bottomBar, placement2: ToolbarItemPlacement.bottomBar)
+            #endif
+        case .bottomGroup:
+            #if os(macOS) // ToolbarItemPlacement.bottomBar unavailable on macOS
+            Text("Not supported on macOS")
+            #else
+            ToolbarBottomThreePlayground(spaced: false)
+            #endif
+        case .bottomSpaced:
+            #if os(macOS) // ToolbarItemPlacement.bottomBar unavailable on macOS
+            Text("Not supported on macOS")
+            #else
+            ToolbarBottomThreePlayground(spaced: true)
+            #endif
+        case .customToolbarContent:
+            #if os(macOS) // ToolbarItemPlacement.topBarLeading unavailable on macOS
+            Text("Not supported on macOS")
+            #else
+            ToolbarCustomContentPlayground()
+            #endif
+        case .toolbarTitleMenu:
+            ToolbarTitleMenuPlayground()
+        case .toolbarTitleMenuModifier:
+            ToolbarTitleMenuModifierPlayground()
+        }
+    }
 }
 
 struct ToolbarPlayground: View {
     var body: some View {
-        List(ToolbarPlaygroundType.allCases, id: \.self) { type in
-            NavigationLink(type.title, value: type)
+        List {
+            ForEach(ToolbarPlaygroundType.allCases, id: \.self) { type in
+                NavigationLink(type.title, value: type)
+            }
         }
         .toolbar {
             PlaygroundSourceLink(file: "ToolbarPlayground.swift")
         }
         .navigationDestination(for: ToolbarPlaygroundType.self) {
-            switch $0 {
-            case .hideNavigationBar:
-                #if os(macOS)
-                Text("Not supported on macOS")
-                #else
-                HideToolbarsPlayground()
-                    .navigationTitle($0.title)
-                    .toolbar(.hidden, for: .navigationBar)
-                    .ignoresSafeArea(edges: .top)
-                #endif
-            case .hideBars:
-                #if os(macOS)
-                Text("Not supported on macOS")
-                #else
-                HideToolbarsPlayground()
-                    .navigationTitle($0.title)
-                    .toolbar(.hidden)
-                    .ignoresSafeArea()
-                #endif
-            case .hideBarBackgrounds:
-                #if os(macOS)
-                Text("Not supported on macOS")
-                #else
-                HideToolbarsPlayground()
-                    .navigationTitle($0.title)
-                    .toolbarBackground(.hidden, for: .navigationBar, .tabBar)
-                #endif
-            case .customBarColor:
-                #if os(macOS)
-                Text("Not supported on macOS")
-                #else
-                HideToolbarsPlayground()
-                    .navigationTitle($0.title)
-                    .toolbarBackground(.blue, for: .navigationBar, .tabBar)
-                #endif
-            case .visibleCustomBarColor:
-                #if os(macOS)
-                Text("Not supported on macOS")
-                #else
-                HideToolbarsPlayground()
-                    .navigationTitle($0.title)
-                    .toolbarBackground(.blue, for: .navigationBar, .tabBar)
-                    .toolbarBackground(.visible, for: .navigationBar, .tabBar)
-                #endif
-            case .customBarBrush:
-                #if os(macOS)
-                Text("Not supported on macOS")
-                #else
-                HideToolbarsPlayground()
-                    .navigationTitle($0.title)
-                    .toolbarBackground(.blue.gradient, for: .navigationBar, .tabBar)
-                #endif
-            case .customInlineBarBrush:
-                #if os(macOS)
-                Text("Not supported on macOS")
-                #else
-                HideToolbarsPlayground()
-                    .navigationTitle($0.title)
-                    .navigationBarTitleDisplayMode(.inline)
-                    .toolbarBackground(.blue.gradient, for: .navigationBar, .tabBar)
-                #endif
-            case .customBarColorScheme:
-                #if os(macOS)
-                Text("Not supported on macOS")
-                #else
-                HideToolbarsPlayground()
-                    .navigationTitle($0.title)
-                    .toolbarColorScheme(.dark, for: .navigationBar, .tabBar)
-                #endif
-            case .customBarColorSchemeBrush:
-                #if os(macOS)
-                Text("Not supported on macOS")
-                #else
-                HideToolbarsPlayground()
-                    .navigationTitle($0.title)
-                    .toolbarColorScheme(.dark, for: .navigationBar, .tabBar)
-                    .toolbarBackground(.blue.gradient, for: .navigationBar, .tabBar)
-                #endif
-            case .default:
-                DefaultToolbarItemPlayground()
-                    .navigationTitle($0.title)
-            case .updating:
-                UpdatingToolbarItemPlayground()
-                    .navigationTitle($0.title)
-            case .tint:
-                TintToolbarItemGroupPlayground()
-                    .navigationTitle($0.title)
-            case .custom:
-                CustomToolbarItemPlayground()
-                    .navigationTitle($0.title)
-            case .label:
-                LabelToolbarItemPlayground()
-                    .navigationTitle($0.title)
-            case .toolbarItem:
-                ToolbarItemPlayground(placement: ToolbarItemPlacement.automatic, placement2: ToolbarItemPlacement.automatic)
-                    .navigationTitle($0.title)
-            case .toolbarItemGroup:
-                ToolbarItemGroupPlayground(placement: ToolbarItemPlacement.automatic)
-                    .navigationTitle($0.title)
-            case .topLeadingItem:
-                #if os(macOS) // ToolbarItemPlacement.topBarLeading unavailable on macOS
-                #else
-                ToolbarItemPlayground(placement: ToolbarItemPlacement.topBarLeading)
-                    .navigationTitle($0.title)
-                #endif
-            case .topLeadingItemGroup:
-                #if os(macOS) // ToolbarItemPlacement.topBarLeading unavailable on macOS
-                #else
-                ToolbarItemGroupPlayground(placement: ToolbarItemPlacement.topBarLeading)
-                    .navigationTitle($0.title)
-                #endif
-            case .topLeadingBackButtonHidden:
-                #if os(macOS) // ToolbarItemPlacement.topBarLeading unavailable on macOS
-                #else
-                ToolbarBackButtonHiddenPlayground()
-                    .navigationTitle($0.title)
-                #endif
-            case .topLeadingTrailingItems:
-                #if os(macOS) // ToolbarItemPlacement.topBarLeading unavailable on macOS
-                #else
-                ToolbarItemPlayground(placement: ToolbarItemPlacement.topBarLeading, placement2: ToolbarItemPlacement.topBarTrailing)
-                    .navigationTitle($0.title)
-                #endif
-            case .principalItem:
-                ToolbarItemPrincipalPlayground()
-                    .navigationTitle($0.title)
-            case .bottom:
-                #if os(macOS) // ToolbarItemPlacement.bottomBar unavailable on macOS
-                #else
-                ToolbarItemPlayground(placement: ToolbarItemPlacement.bottomBar, placement2: ToolbarItemPlacement.bottomBar)
-                    .navigationTitle($0.title)
-                #endif
-            case .bottomPlain:
-                #if os(macOS) // ToolbarItemPlacement.bottomBar unavailable on macOS
-                #else
-                ToolbarItemPlainStylePlayground(placement: ToolbarItemPlacement.bottomBar, placement2: ToolbarItemPlacement.bottomBar)
-                    .navigationTitle($0.title)
-                #endif
-            case .bottomGroup:
-                #if os(macOS) // ToolbarItemPlacement.bottomBar unavailable on macOS
-                #else
-                ToolbarBottomThreePlayground(spaced: false)
-                    .navigationTitle($0.title)
-                #endif
-            case .bottomSpaced:
-                #if os(macOS) // ToolbarItemPlacement.bottomBar unavailable on macOS
-                #else
-                ToolbarBottomThreePlayground(spaced: true)
-                    .navigationTitle($0.title)
-                #endif
-            case .customToolbarContent:
-                #if os(macOS) // ToolbarItemPlacement.topBarLeading unavailable on macOS
-                #else
-                ToolbarCustomContentPlayground()
-                    .navigationTitle($0.title)
-                #endif
-            case .toolbarTitleMenu:
-                ToolbarTitleMenuPlayground()
-                    .navigationTitle($0.title)
-            case .toolbarTitleMenuModifier:
-                ToolbarTitleMenuModifierPlayground()
-                    .navigationTitle($0.title)
-            }
+            $0.navigationTitle($0.title)
         }
     }
 }
@@ -291,7 +283,7 @@ struct DefaultToolbarItemPlayground: View {
 
     var body: some View {
         List {
-            Button("Pop") {
+            Button("Pop \(firstTapCount) / \(secondTapCount)") {
                 dismiss()
             }
             ForEach(0..<100) { i in
@@ -378,6 +370,49 @@ struct LabelToolbarItemPlayground: View {
                 Label("Dismiss", systemImage: "trash")
             }
         }
+    }
+}
+
+struct StatefulToolbarItemPlayground: View {
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        List {
+            Button("Pop") {
+                dismiss()
+            }
+            ForEach(0..<100) { i in
+                Text("Content \(i)")
+            }
+        }
+        .toolbar {
+            ToolbarPlaygroundStatefulItem()
+        }
+    }
+}
+
+struct ToolbarPlaygroundStatefulItem: ToolbarContent {
+    @State var sheetIsPresented = false
+
+    var body: some ToolbarContent {
+        ToolbarItem {
+            Button(action: {
+                sheetIsPresented = true
+            }) {
+                Image(systemName: "bell")
+            }
+            .sheet(isPresented: $sheetIsPresented) {
+                ToolbarPlaygroundSheetView()
+            }
+        }
+    }
+}
+
+struct ToolbarPlaygroundSheetView : View {
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        Button("Dismiss") { dismiss() }
     }
 }
 

--- a/Sources/Showcase/ZIndexPlayground.swift
+++ b/Sources/Showcase/ZIndexPlayground.swift
@@ -48,5 +48,8 @@ struct ZIndexPlayground: View {
             }
             .padding()
         }
+        .toolbar {
+            PlaygroundSourceLink(file: "ZIndexPlayground.swift")
+        }
     }
 }

--- a/Sources/ShowcaseApp/ShowcaseAppMain.swift
+++ b/Sources/ShowcaseApp/ShowcaseAppMain.swift
@@ -1,7 +1,0 @@
-// Copyright 2023–2025 Skip
-import SwiftUI
-import Showcase
-
-/// The entry point to the app simply loads the App implementation from SPM module.
-@main struct AppMain: App, ShowcaseApp {
-}


### PR DESCRIPTION
This change enables the app to be run in either Skip Fuse or Skip Lite mode by simply toggling the default value of `SKIP_MODE` in `Package.swift` and making the corresponding change to the skip `mode` in `Sources/Showcase/Skip/skip.yml`. This should enable us to develop playgrounds for various features in a single place rather than duplicating them across two separate repositories, and will also help highlight the features that are supported by `lite` and not `fuse`, and vice-versa.