### PR TITLE
Enable swipe actions in ListPlayground on Skip (Light) 

### DIFF
--- a/Sources/Showcase/ListPlayground.swift
+++ b/Sources/Showcase/ListPlayground.swift
@@ -822,7 +822,6 @@ struct SwipeActionsListPlayground: View {
                 .padding(8)
             List {
                 ForEach(rows, id: \.self) { i in
-                    #if !SKIP
                     Text("Row \(i) — Add to favorites")
                         .swipeActions(edge: .trailing) {
                             Button("Pin") {
@@ -840,12 +839,6 @@ struct SwipeActionsListPlayground: View {
                             }
                             .tint(.orange)
                         }
-                    #else
-                    Text("Row \(i) — Add to favorites")
-                    #endif
-                }
-                .onDelete { offsets in
-                    rows.remove(atOffsets: offsets)
                 }
             }
         }


### PR DESCRIPTION
Currently, swipe actions are disabled when the app is compiled using Skip (Light).
This PR resolves this issue by simply removing the "#if !SKIP" expression.

---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

