### PR TITLE
Added NSFaceIDUsageDescription Key to InfoPlist

### DIFF
--- a/Darwin/Showcase.xcconfig
+++ b/Darwin/Showcase.xcconfig
@@ -31,6 +31,7 @@ INFOPLIST_KEY_NSMotionUsageDescription = "This app accesses motion sensors to de
 INFOPLIST_KEY_NSContactsUsageDescription = "This app accesses your contacts to demonstrate the SkipContacts framework";
 INFOPLIST_KEY_NSCalendarsUsageDescription = "This app accesses your calendar to demonstrate the SkipCalendar framework";
 INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "This app needs full access to your calendar to demonstrate creating and editing events with the SkipCalendar framework";
+INFOPLIST_KEY_NSFaceIDUsageDescription = "This app uses Face ID to demonstrate biometric authentication";
 
 IPHONEOS_DEPLOYMENT_TARGET = 17.0
 MACOSX_DEPLOYMENT_TARGET = 14.0


### PR DESCRIPTION
This PR adds the required `NSFaceIDUsageDescription` key to the Info.plist.

When I added the `BiometricAuthenticationPlayground` in https://github.com/skiptools/skipapp-showcase/pull/116, I tested it on the iOS Simulator and on an Android device, where everything worked as expected. However, after installing the latest version of Skip Showcase from the App Store, I discovered that the app crashes on physical iOS/iPadOS devices when attempting Face ID authentication. This is because accessing Face ID on physical iOS/iPadOS devices requires the `NSFaceIDUsageDescription` key in the app's Info.plist, which I unfortunately hadn't realized earlier.

To help prevent others from running into the same issue, I also updated the README in SkipKit in https://github.com/skiptools/skip-kit/pull/39 to mention that this Info.plist entry is required when using biometric authentication on iOS/iPadOS.

Sorry for the inconvenience!

---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

